### PR TITLE
ENH: specify scan_id_source to RE as None

### DIFF
--- a/apstools/snapshot.py
+++ b/apstools/snapshot.py
@@ -135,7 +135,7 @@ def snapshot_cli():
     time.sleep(2)   # FIXME: allow time to connect
     
     db = Broker.named(args.broker_config)
-    RE = RunEngine({})
+    RE = RunEngine({}, scan_id_source=None)
     RE.subscribe(db.insert)
 
     uuid_list = RE(APS_plans.snapshot(obj_dict.values(), md=md))


### PR DESCRIPTION
This change is contingent on merging the corresponding Bluesky PR https://github.com/NSLS-II/bluesky/pull/1175, that's why creating it as a "Draft pull request" until after the Bluesky PR is merged.