### PR TITLE
epid: remove clock_ticks field

### DIFF
--- a/apstools/synApps/epid.py
+++ b/apstools/synApps/epid.py
@@ -60,7 +60,6 @@ class EpidRecord(EpicsRecordFloatFields, EpicsRecordDeviceCommonAll):
     calculated_I = Component(EpicsSignal, ".I")
     calculated_D = Component(EpicsSignalRO, ".D")
 
-    clock_ticks = Component(EpicsSignalRO, ".CT")
     time_difference = Component(EpicsSignal, ".DT")
     minimum_delta_time = Component(EpicsSignal, ".MDT")
 


### PR DESCRIPTION
fixes #326, the `.CT` field is not available through channel access.  It is marked `DBF_NOACCESS` [as noted](https://github.com/BCDA-APS/apstools/issues/326#issuecomment-648933917).