### PR TITLE
Undulator and Kohzu monochromator functionalities

### DIFF
--- a/apstools/devices.py
+++ b/apstools/devices.py
@@ -911,9 +911,9 @@ class TrackingSignal(Signal):
         ------
         ValueError
         """
-        if type(value) != bool:
-            msg = 'tracking is boolean, it can only be True or False.'
-            raise ValueError(msg)
+        if not isinstance(value, bool):
+            raise ValueError(
+                'tracking is boolean, it can only be True or False.')
 
 
 class ApsUndulator(Device):
@@ -956,34 +956,6 @@ class ApsUndulator(Device):
     energy_backlash = Component(Signal, value=0.0, kind='config')
     energy_offset = Component(Signal, value=0, kind='config')
     tracking = Component(TrackingSignal, value=False, kind='config')
-
-    def undulator_setup(self):
-        """Interactive setup of usual undulator parameters."""
-        while True:
-            msg = "Do you want to track the undulator energy? (yes/no): "
-            _tracking = input(msg)
-            if _tracking == 'yes':
-                self.tracking.put(True)
-                break
-            elif _tracking == 'no':
-                self.tracking.put(False)
-            else:
-                print("Only yes or no are valid answers.")
-
-        if _tracking == 'yes':
-            while True:
-                msg = "Undulator offset (keV) ({:0.3f}): "
-                _offset = input(msg.format(self.offset.get()))
-                try:
-                    self.offset.put(float(_offset))
-                    break
-                except ValueError:
-                    if _offset == '':
-                        msg = 'Using offset = {:0.3f} keV'
-                        print(msg.format(self.offset.get()))
-                        break
-                    else:
-                        print("The undulator offset has to be a number.")
 
 
 class ApsUndulatorDual(Device):

--- a/apstools/devices.py
+++ b/apstools/devices.py
@@ -952,8 +952,8 @@ class ApsUndulator(Device):
     version = Component(EpicsSignalRO, "Version", kind='config')
 
     # Useful undulator parameters that are not EPICS PVs.
-    energy_deadband = Component(Signal, value=0.002, kind='config')
-    energy_backlash = Component(Signal, value=0.25, kind='config')
+    energy_deadband = Component(Signal, value=0.0, kind='config')
+    energy_backlash = Component(Signal, value=0.0, kind='config')
     energy_offset = Component(Signal, value=0, kind='config')
     tracking = Component(TrackingSignal, value=False, kind='config')
 
@@ -1510,6 +1510,18 @@ class KohzuSeqCtl_Monochromator(Device):
         """for command-line use:  ``kohzu_mono.energy_move(8.2)``"""
         self.energy.put(energy)
         self.move_button.put(1)
+
+    def calibrate_energy(self, value):
+        """Calibrate the mono energy.
+
+        Parameters
+        ----------
+        value: float
+            New energy for the current monochromator position.
+        """
+        self.use_set.put('Set')
+        self.energy.put(value)
+        self.use_set.put('Use')
 
 
 class ProcessController(Device):

--- a/apstools/devices.py
+++ b/apstools/devices.py
@@ -979,7 +979,7 @@ class ApsUndulator(Device):
                     break
                 except ValueError:
                     if _offset == '':
-                        msg = 'Using offset = {} keV'
+                        msg = 'Using offset = {:0.3f} keV'
                         print(msg.format(self.offset.get()))
                         break
                     else:

--- a/apstools/devices.py
+++ b/apstools/devices.py
@@ -985,20 +985,6 @@ class ApsUndulator(Device):
                     else:
                         print("The undulator offset has to be a number.")
 
-        while True:
-            msg = "Undulator taper (keV) ({:0.3f}): "
-            _taper = input(msg.format(self.energy_taper.get()))
-            try:
-                self.energy_taper.put(float(_taper))
-                break
-            except ValueError:
-                if _offset == '':
-                    msg = 'Using offset = {} keV'
-                    print(msg.format(self.energy_taper.get()))
-                    break
-                else:
-                    print("The undulator taper has to be a number.")
-
 
 class ApsUndulatorDual(Device):
     """


### PR DESCRIPTION
##### `ApsUndulator`

-  Adds some `Signal` components that are helpful in moving the undulator (as far as I know these don't exist in the EPICS support).

- Interactive `.undulator_setup` - this is certainly useful for 4-ID-D, not sure others would want it.

##### `KohzuSeqCtl_Monochromator`

- Adds `.calibrate_energy`.