### PR TITLE
use first camera trigger mode when priming AD plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Change History
 
 :1.4.1:  release expected by 2021-01-22
 
+    * `#488 <https://github.com/BCDA-APS/apstools/pull/488>`_
+       use first trigger_mode when priming AD plugin
+
     * `#487 <https://github.com/BCDA-APS/apstools/pull/487>`_
        ensure spec2ophyd code is packaged
 

--- a/apstools/devices.py
+++ b/apstools/devices.py
@@ -1915,8 +1915,11 @@ def AD_prime_plugin2(plugin):
         [
             (plugin.enable, 1),
             (plugin.parent.cam.array_callbacks, 1),  # set by number
-            (plugin.parent.cam.image_mode, "Single"),
-            (plugin.parent.cam.trigger_mode, "Internal"),
+            (plugin.parent.cam.image_mode, 0),  # Single, set by number
+            # Trigger mode names are not identical for every camera.
+            # Assume here that the first item in the list is
+            # the best default choice to prime the plugin.
+            (plugin.parent.cam.trigger_mode, 0),  # set by number
             # just in case the acquisition time is set very long...
             (plugin.parent.cam.acquire_time, 1),
             (plugin.parent.cam.acquire_period, 1),


### PR DESCRIPTION
fix #485, set by number since names are not identical between cameras