### PR TITLE
Support for LabJack DAQ devices

### DIFF
--- a/apstools/devices/__init__.py
+++ b/apstools/devices/__init__.py
@@ -68,6 +68,8 @@ from .kohzu_monochromator import KohzuSeqCtl_Monochromator
 from .lakeshore_controllers import LakeShore336Device
 from .lakeshore_controllers import LakeShore340Device
 
+from .labjack import LabJackT4, LabJackT7, LabJackT7Pro, LabJackT8
+
 from .linkam_controllers import Linkam_CI94_Device
 from .linkam_controllers import Linkam_T96_Device
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -394,7 +394,7 @@ class LabJackT4(LabJackBase):
     # Inherit the docstring from the base class
     # (needed for sphinx auto API)
     __doc__ = LabJackBase.__doc__
-    
+
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(12), kind="normal")
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -26,10 +26,10 @@ that individual inputs can be used as part of other devices. Assuming
 analog input 5 is connected to a gas flow meter:
 
 .. code:: python
-    
+
     from ophyd import Component as Cpt
     from apstools.devices import labjack
-    
+
     class MyBeamline(Device):
         ...
         gas_flow = Cpt(labjack.AnalogInput, "LabJackT7_1:Ai5")
@@ -317,11 +317,11 @@ def make_digital_ios(num_dios: int):
     for n in range(num_dios):
         defn[f"dio{n}"] = (DigitalIO, "", dict(ch_num=n))
     # Add the digital word outputs
-    defn[f"dio"] = (EpicsSignalRO, "DIOIn", dict(kind=Kind.normal))
-    defn[f"fio"] = (EpicsSignalRO, "FIOIn", dict(kind=Kind.normal))
-    defn[f"eio"] = (EpicsSignalRO, "EIOIn", dict(kind=Kind.normal))
-    defn[f"cio"] = (EpicsSignalRO, "CIOIn", dict(kind=Kind.normal))
-    defn[f"mio"] = (EpicsSignalRO, "MIOIn", dict(kind=Kind.normal))
+    defn["dio"] = (EpicsSignalRO, "DIOIn", dict(kind=Kind.normal))
+    defn["fio"] = (EpicsSignalRO, "FIOIn", dict(kind=Kind.normal))
+    defn["eio"] = (EpicsSignalRO, "EIOIn", dict(kind=Kind.normal))
+    defn["cio"] = (EpicsSignalRO, "CIOIn", dict(kind=Kind.normal))
+    defn["mio"] = (EpicsSignalRO, "MIOIn", dict(kind=Kind.normal))
     return defn
 
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -16,13 +16,15 @@ Supported devices, all inherit from ``LabJackBase``:
 - T7Pro
 - T8
 
-These devices are **based on the v3.0.0 EPICS module**. The EPICS IOC
-database changed significantly from v2 to v3 when the module was
+These devices are **based on EPICS LabJack module R3.0**. The EPICS IOC
+database changed significantly from R2 to R3 when the module was
 rewritten to use the LJM library.
 
+.. see:: https://github.com/epics-modules/LabJack/releases/tag/R3-0
+
 There are definitions for the entire LabJack device, as well as the
-various inputs/outputs available on the LabJack T-series. These means
-that individual inputs can be used as part of other devices. Assuming
+various inputs/outputs available on the LabJack T-series.
+Individual inputs can be used as part of other devices. Assuming
 analog input 5 is connected to a gas flow meter:
 
 .. code:: python
@@ -340,7 +342,7 @@ class LabJackBase(Device):
     - waveform digitizer* (:py:class:`~apstools.devices.labjack.WaveformDigitizer`)
     - waveform generator (:py:class:`~apstools.devices.labjack.WaveformGenerator`)
 
-    \\* The number of inputs and digital outputs depends on the specific
+    The number of inputs and digital outputs depends on the specific
     LabJack T-series device being used. Therefore, the base device
     ``LabJackBase`` does not implement these I/O signals. Instead,
     consider using one of the subclasses, like ``LabJackT4``.

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -48,9 +48,19 @@ from apstools.synApps import EpicsRecordDeviceCommonAll
 from apstools.synApps import EpicsRecordInputFields
 from apstools.synApps import EpicsRecordOutputFields
 
-
-__all__ = ["AnalogOutput", "AnalogInput", "DigitalIO", "WaveformDigitizer", "make_digitizer_waveforms",
-           "WaveformGenerator", "LabJackBase", "LabJackT4", "LabJackT7", "LabJackT7Pro", "LabJackT8"]
+__all__ = [
+    "AnalogOutput",
+    "AnalogInput",
+    "DigitalIO",
+    "WaveformDigitizer",
+    "make_digitizer_waveforms",
+    "WaveformGenerator",
+    "LabJackBase",
+    "LabJackT4",
+    "LabJackT7",
+    "LabJackT7Pro",
+    "LabJackT8",
+]
 
 
 class Input(EpicsRecordInputFields, EpicsRecordDeviceCommonAll):
@@ -60,6 +70,7 @@ class Input(EpicsRecordInputFields, EpicsRecordDeviceCommonAll):
     field is used as a trigger. This way, even if the .SCAN field is
     set to passive, the record will still update before being read.
     """
+
     process_record = Cpt(EpicsSignal, ".PROC", kind="omitted", put_complete=True, trigger_value=1)
     final_value = Cpt(EpicsSignalRO, ".VAL", kind="normal", auto_monitor=False)
 
@@ -75,13 +86,14 @@ class BinaryOutput(Output):
     Similar to a common EPICS input without the OVAL record.
 
     """
+
     output_value = None
 
 
 class AnalogOutput(Output):
     """An analog output on a labjack device."""
-    pass
 
+    pass
 
 
 class AnalogInput(Input):
@@ -96,6 +108,7 @@ class AnalogInput(Input):
     can be useful if the .SCAN field is set to passive.
 
     """
+
     differential = FCpt(
         EpicsSignal,
         "{self.base_prefix}Diff{self.ch_num}",
@@ -144,6 +157,7 @@ class DigitalIO(Device):
     (``Bo3``), and direction (``Bd3``) records.
 
     """
+
     ch_num: int
 
     input = FCpt(Input, "{prefix}Bi{ch_num}")
@@ -209,9 +223,8 @@ def make_digitizer_waveforms(num_ais: int):
 
 
 class WaveformGenerator(Device):
-    """A feature of the Labjack devices that generates output waveforms.
+    """A feature of the Labjack devices that generates output waveforms."""
 
-    """
     external_trigger = Cpt(EpicsSignal, "WaveGenExtTrigger", kind=Kind.config)  # config
     external_clock = Cpt(EpicsSignal, "WaveGenExtClock", kind=Kind.config)  # config
     continuous = Cpt(EpicsSignal, "WaveGenContinuous", kind=Kind.config)  # config
@@ -237,7 +250,7 @@ class WaveformGenerator(Device):
     internal_time_waveform = Cpt(EpicsSignal, "WaveGenIntTimeWF", kind=Kind.normal)  # normal
     internal_dwell = Cpt(EpicsSignal, "WaveGenIntDwell", kind=Kind.omitted)  # omitted
     internal_frequency = Cpt(EpicsSignal, "WaveGenIntFrequency", kind=Kind.omitted)  # omitted
-    
+
     # Waveform specific settings
     user_waveform_0 = Cpt(EpicsSignal, "WaveGenUserWF0", kind=Kind.config)  # config
     internal_waveform_0 = Cpt(EpicsSignalRO, "WaveGenInternalWF0", kind=Kind.omitted)  # omitted
@@ -253,7 +266,6 @@ class WaveformGenerator(Device):
     pulse_width_1 = Cpt(EpicsSignal, "WaveGenPulseWidth1", kind=Kind.config)  # config
     amplitude_1 = Cpt(EpicsSignal, "WaveGenAmplitude1", kind=Kind.config)  # config
     offset_1 = Cpt(EpicsSignal, "WaveGenOffset1", kind=Kind.config)  # config
-    
 
 
 def make_analog_inputs(num_ais: int):
@@ -348,11 +360,11 @@ class LabJackBase(Device):
     .. code:: python
 
         lj = LabJackT4(...)
-        
+
         # Read a waveform from the digitizer
         lj.waveform_digitizer.trigger().wait()
         lj.waveform_digitizer.read()
-        
+
         # Same thing for the waveform generator
         lj.waveform_generator.trigger().wait()
 
@@ -385,7 +397,7 @@ class LabJackT4(LabJackBase):
     analog_inputs = DCpt(make_analog_inputs(12), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(16), kind=(Kind.config | Kind.normal))
     waveform_digitizer = Cpt(WaveformDigitizer, "", kind=Kind.omitted)
-    
+
 
 class LabJackT7(LabJackBase):
     class WaveformDigitizer(WaveformDigitizer):
@@ -394,7 +406,8 @@ class LabJackT7(LabJackBase):
     analog_inputs = DCpt(make_analog_inputs(14), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(23), kind=(Kind.config | Kind.normal))
     waveform_digitizer = Cpt(WaveformDigitizer, "")
-    
+
+
 class LabJackT7Pro(LabJackBase):
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
@@ -411,4 +424,3 @@ class LabJackT8(LabJackBase):
     analog_inputs = DCpt(make_analog_inputs(8), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(20), kind=(Kind.config | Kind.normal))
     waveform_digitizer = Cpt(WaveformDigitizer, "")
-    

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -128,11 +128,65 @@ def make_digitizer_waveforms(num_ais: int):
     return defn
 
 
+class WaveformGenerator(Device):
+    """A feature of the Labjack devices that generates output waveforms.
+
+    By itself, this device does not include any actual data. It should
+    be sub-classed for the individual T-series devices to use
+    ``make_digitizer_waveforms`` to produce waveform signals based on
+    the number of inputs, using the ophyd DynamicDeviceComponent.
+
+    .. code:: python
+
+        class T7Digitizer(WaveformDigitizer):
+            waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
+
+    """
+    external_trigger = Cpt(EpicsSignal, "WaveGenExtTrigger", kind=Kind.config)  # config
+    external_clock = Cpt(EpicsSignal, "WaveGenExtClock", kind=Kind.config)  # config
+    continuous = Cpt(EpicsSignal, "WaveGenContinuous", kind=Kind.config)  # config
+    run = Cpt(EpicsSignal, "WaveGenRun", trigger_value=1, kind=Kind.omitted)  # omitted
+
+    # These signals give a readback based on whether user-defined or
+    # internal waves are used
+    num_points = Cpt(EpicsSignalRO, "WaveGenNumPoints", kind=Kind.config)  # config
+    current_point = Cpt(EpicsSignalRO, "WaveGenCurrentPoint", kind=Kind.omitted)  # omitted
+    frequency = Cpt(EpicsSignalRO, "WaveGenFrequency", kind=Kind.normal)  # normal
+    dwell = Cpt(EpicsSignalRO, "WaveGenDwell", kind=Kind.normal)  # normal
+    dwell_actual = Cpt(EpicsSignalRO, "WaveGenDwellActual", kind=Kind.normal)  # normal
+    total_time = Cpt(EpicsSignalRO, "WaveGenTotalTime", kind=Kind.normal)  # normal
+
+    # Settings for user-defined waveforms
+    user_num_points = Cpt(EpicsSignal, "WaveGenUserNumPoints", kind=Kind.omitted)  # omitted
+    user_time_waveform = Cpt(EpicsSignal, "WaveGenUserTimeWF", kind=Kind.normal)  # normal
+    user_dwell = Cpt(EpicsSignal, "WaveGenUserDwell", kind=Kind.omitted)  # omitted
+    user_frequency = Cpt(EpicsSignal, "WaveGenUserFrequency", kind=Kind.omitted)  # omitted
+
+    # Settings for internal waveforms
+    internal_num_points = Cpt(EpicsSignal, "WaveGenIntNumPoints", kind=Kind.omitted)  # omitted
+    internal_time_waveform = Cpt(EpicsSignal, "WaveGenIntTimeWF", kind=Kind.normal)  # normal
+    internal_dwell = Cpt(EpicsSignal, "WaveGenIntDwell", kind=Kind.omitted)  # omitted
+    internal_frequency = Cpt(EpicsSignal, "WaveGenIntFrequency", kind=Kind.omitted)  # omitted
+    
+    # Waveform specific settings
+    user_waveform_0 = Cpt(EpicsSignal, "WaveGenUserWF0", kind=Kind.config)  # config
+    internal_waveform_0 = Cpt(EpicsSignalRO, "WaveGenIntWF0", kind=Kind.omitted)  # omitted
+    enable_0 = Cpt(EpicsSignal, "WaveGenEnable0", kind=Kind.config)  # config
+    type_0 = Cpt(EpicsSignal, "WaveGenType0", kind=Kind.config)  # config
+    pulse_width_0 = Cpt(EpicsSignal, "WaveGenPulaseWidth0", kind=Kind.config)  # config
+    amplitude_0 = Cpt(EpicsSignal, "WaveGenAmplitude0", kind=Kind.config)  # config
+    offset_0 = Cpt(EpicsSignal, "WaveGenOffset0", kind=Kind.config)  # config
+    user_waveform_1 = Cpt(EpicsSignal, "WaveGenUserWF1", kind=Kind.config)  # config
+    internal_waveform_1 = Cpt(EpicsSignalRO, "WaveGenIntWF1", kind=Kind.omitted)  # omitted
+    enable_1 = Cpt(EpicsSignal, "WaveGenEnable1", kind=Kind.config)  # config
+    type_1 = Cpt(EpicsSignal, "WaveGenType1", kind=Kind.config)  # config
+    pulse_width_1 = Cpt(EpicsSignal, "WaveGenPulaseWidth1", kind=Kind.config)  # config
+    amplitude_1 = Cpt(EpicsSignal, "WaveGenAmplitude1", kind=Kind.config)  # config
+    offset_1 = Cpt(EpicsSignal, "WaveGenOffset1", kind=Kind.config)  # config
+    
+
 class LabJackBase(Device):
     """A labjack T-series data acquisition unit (DAQ).
-
-    This device is meant as a base for specific device subclasses. It
-    does not have any inputs or outputs.
 
     """
 
@@ -149,6 +203,7 @@ class LabJackBase(Device):
     analog_in_resolution_all = Cpt(EpicsSignal, "AiAllResolution", kind=Kind.config)
     analog_in_sampling_rate = Cpt(EpicsSignal, "AiSamplingRate", kind=Kind.config)
     device_reset = Cpt(EpicsSignal, "DeviceReset", kind=Kind.omitted)
+    waveform_generator = Cpt(WaveformGenerator, "")
 
 
 def make_analog_inputs(num_ais: int):
@@ -216,3 +271,4 @@ class LabJackT7(LabJackBase):
     analog_outputs = DCpt(make_analog_outputs(2), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(23), kind=(Kind.config | Kind.normal))
     waveform_digitizer = Cpt(WaveformDigitizer, "")
+    

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -287,7 +287,7 @@ def make_analog_inputs(num_ais: int):
     return defn
 
 
-def make_analog_outputs(num_ais: int):
+def make_analog_outputs(num_aos: int):
     """Create a dictionary with analog output device definitions.
 
     For use with an ophyd DynamicDeviceComponent.
@@ -299,7 +299,7 @@ def make_analog_outputs(num_ais: int):
 
     """
     defn = {}
-    for n in range(num_ais):
+    for n in range(num_aos):
         defn[f"ao{n}"] = (AnalogOutput, f"Ao{n}", {})
     return defn
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -1,6 +1,15 @@
-"""Ophyd definitions for Labjack T-series data acquisition devices.
+"""
+LabJack Data Acquisition (DAQ)
++++++++++++++++++++++++++++++++++++++++
 
-Supported devices:
+.. autosummary::
+
+   ~LabJackBase
+
+
+Ophyd definitions for Labjack T-series data acquisition devices.
+
+Supported devices, all inherit from ``LabJackBase``:
 
 - T4
 - T7
@@ -40,8 +49,8 @@ from apstools.synApps import EpicsRecordInputFields
 from apstools.synApps import EpicsRecordOutputFields
 
 
-__all__ = ["AnalogOutput", "AnalogInput", "DigitalIO", "WaveformDigitizer",
-           "WaveformGenerator", "LabJackT4", "LabJackT7", "LabJackT7Pro", "LabJackT8"]
+__all__ = ["AnalogOutput", "AnalogInput", "DigitalIO", "WaveformDigitizer", "make_digitizer_waveforms",
+           "WaveformGenerator", "LabJackBase", "LabJackT4", "LabJackT7", "LabJackT7Pro", "LabJackT8"]
 
 
 class Input(EpicsRecordInputFields, EpicsRecordDeviceCommonAll):
@@ -132,7 +141,7 @@ class DigitalIO(Device):
         dio3 = DigitalIO("LabJackT7_1:", name="dio3", ch_num=3)
 
     This will create signals for the input (``Bi3``), output
-    (``Bo3``), direction (``Bd3``) records.
+    (``Bo3``), and direction (``Bd3``) records.
 
     """
     ch_num: int
@@ -151,8 +160,9 @@ class WaveformDigitizer(Device):
 
     By itself, this device does not include any actual data. It should
     be sub-classed for the individual T-series devices to use
-    ``make_digitizer_waveforms`` to produce waveform signals based on
-    the number of inputs, using the ophyd DynamicDeviceComponent.
+    :py:func:`~apstools.devices.labjack.make_digitizer_waveforms` to
+    produce waveform signals based on the number of inputs, using the
+    ophyd DynamicDeviceComponent.
 
     .. code:: python
 
@@ -200,16 +210,6 @@ def make_digitizer_waveforms(num_ais: int):
 
 class WaveformGenerator(Device):
     """A feature of the Labjack devices that generates output waveforms.
-
-    By itself, this device does not include any actual data. It should
-    be sub-classed for the individual T-series devices to use
-    ``make_digitizer_waveforms`` to produce waveform signals based on
-    the number of inputs, using the ophyd DynamicDeviceComponent.
-
-    .. code:: python
-
-        class T7Digitizer(WaveformDigitizer):
-            waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
 
     """
     external_trigger = Cpt(EpicsSignal, "WaveGenExtTrigger", kind=Kind.config)  # config
@@ -316,14 +316,17 @@ def make_digital_ios(num_dios: int):
 class LabJackBase(Device):
     """A labjack T-series data acquisition unit (DAQ).
 
+    To use the individual components separately, consider using the
+    corresponding devices in the list below.
+
     This device contains signals for the following:
 
     - device information (e.g. firmware version ,etc)
-    - analog outputs
-    - analog inputs*
-    - digital input/output*
-    - waveform digitizer*
-    - waveform generator
+    - analog outputs (:py:class:`~apstools.devices.labjack.AnalogInput`)
+    - analog inputs* (:py:class:`~apstools.devices.labjack.AnalogOutput`)
+    - digital input/output* (:py:class:`~apstools.devices.labjack.DigitalIO`)
+    - waveform digitizer* (:py:class:`~apstools.devices.labjack.WaveformDigitizer`)
+    - waveform generator (:py:class:`~apstools.devices.labjack.WaveformGenerator`)
 
     * The number of inputs and digital outputs depends on the specific
     LabJack T-series device being used. Therefore, the base device

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -12,6 +12,7 @@ from ophyd import Component as Cpt
 from ophyd import Device
 from ophyd import DynamicDeviceComponent as DCpt
 from ophyd import EpicsSignal
+from ophyd import EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 from ophyd import Kind
 
@@ -146,6 +147,12 @@ def make_digital_ios(num_dios: int):
     defn = {}
     for n in range(num_dios):
         defn[f"dio{n}"] = (DigitalIO, "", dict(ch_num=n))
+    # Add the digital word outputs
+    defn[f"dio"] = (EpicsSignalRO, "DIO", dict(kind=Kind.normal))
+    defn[f"fio"] = (EpicsSignalRO, "FIO", dict(kind=Kind.normal))
+    defn[f"eio"] = (EpicsSignalRO, "EIO", dict(kind=Kind.normal))
+    defn[f"cio"] = (EpicsSignalRO, "CIO", dict(kind=Kind.normal))
+    defn[f"mio"] = (EpicsSignalRO, "MIO", dict(kind=Kind.normal))
     return defn
 
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -340,7 +340,7 @@ class LabJackBase(Device):
     - waveform digitizer* (:py:class:`~apstools.devices.labjack.WaveformDigitizer`)
     - waveform generator (:py:class:`~apstools.devices.labjack.WaveformGenerator`)
 
-    * The number of inputs and digital outputs depends on the specific
+    \\* The number of inputs and digital outputs depends on the specific
     LabJack T-series device being used. Therefore, the base device
     ``LabJackBase`` does not implement these I/O signals. Instead,
     consider using one of the subclasses, like ``LabJackT4``.
@@ -391,6 +391,10 @@ class LabJackBase(Device):
 
 
 class LabJackT4(LabJackBase):
+    # Inherit the docstring from the base class
+    # (needed for sphinx auto API)
+    __doc__ = LabJackBase.__doc__
+    
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(12), kind="normal")
 
@@ -400,6 +404,10 @@ class LabJackT4(LabJackBase):
 
 
 class LabJackT7(LabJackBase):
+    # Inherit the docstring from the base class
+    # (needed for sphinx auto API)
+    __doc__ = LabJackBase.__doc__
+
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
 
@@ -409,6 +417,10 @@ class LabJackT7(LabJackBase):
 
 
 class LabJackT7Pro(LabJackBase):
+    # Inherit the docstring from the base class
+    # (needed for sphinx auto API)
+    __doc__ = LabJackBase.__doc__
+
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
 
@@ -418,6 +430,10 @@ class LabJackT7Pro(LabJackBase):
 
 
 class LabJackT8(LabJackBase):
+    # Inherit the docstring from the base class
+    # (needed for sphinx auto API)
+    __doc__ = LabJackBase.__doc__
+
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(8), kind="normal")
 

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -78,7 +78,11 @@ class Input(EpicsRecordInputFields, EpicsRecordDeviceCommonAll):
 
 
 class Output(EpicsRecordOutputFields, EpicsRecordDeviceCommonAll):
-    pass
+    """A generic output record.
+
+    Intended to be sub-classed into different output types.
+
+    """
 
 
 class BinaryOutput(Output):
@@ -94,8 +98,6 @@ class BinaryOutput(Output):
 
 class AnalogOutput(Output):
     """An analog output on a labjack device."""
-
-    pass
 
 
 class AnalogInput(Input):

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -1,6 +1,6 @@
 """Ophyd definitions for Labjack T-series data acquisition devices.
 
-Currently this is limited to the Labjack T7.
+Currently this is limited to the Labjack T4, T7, T7-Pro, and T8.
 
 These devices are based on the v3.0.0 EPICS module. The EPICS IOC
 database changed significantly from v2 to v3 when the module was
@@ -185,26 +185,6 @@ class WaveformGenerator(Device):
     offset_1 = Cpt(EpicsSignal, "WaveGenOffset1", kind=Kind.config)  # config
     
 
-class LabJackBase(Device):
-    """A labjack T-series data acquisition unit (DAQ).
-
-    """
-
-    model_name = Cpt(EpicsSignal, "ModelName", kind=Kind.config)
-    firmware_version = Cpt(EpicsSignal, "FirmwareVersion", kind=Kind.config)
-    serial_number = Cpt(EpicsSignal, "SerialNumber", kind=Kind.config)
-    device_temperature = Cpt(EpicsSignal, "DeviceTemperature", kind=Kind.config)
-    ljm_version = Cpt(EpicsSignal, "LJMVersion", kind=Kind.config)
-    driver_version = Cpt(EpicsSignal, "DriverVersion", kind=Kind.config)
-    last_error_message = Cpt(EpicsSignal, "LastErrorMessage", kind=Kind.config)
-    poll_sleep_ms = Cpt(EpicsSignal, "PollSleepMS", kind=Kind.config)
-    poll_time_ms = Cpt(EpicsSignal, "PollTimeMS", kind=Kind.omitted)
-    analog_in_settling_time_all = Cpt(EpicsSignal, "AiAllSettlingUS", kind=Kind.config)
-    analog_in_resolution_all = Cpt(EpicsSignal, "AiAllResolution", kind=Kind.config)
-    analog_in_sampling_rate = Cpt(EpicsSignal, "AiSamplingRate", kind=Kind.config)
-    device_reset = Cpt(EpicsSignal, "DeviceReset", kind=Kind.omitted)
-    waveform_generator = Cpt(WaveformGenerator, "")
-
 
 def make_analog_inputs(num_ais: int):
     """Create a dictionary with analog input device definitions.
@@ -263,12 +243,62 @@ def make_digital_ios(num_dios: int):
     return defn
 
 
+class LabJackBase(Device):
+    """A labjack T-series data acquisition unit (DAQ).
+
+    """
+
+    model_name = Cpt(EpicsSignal, "ModelName", kind=Kind.config)
+    firmware_version = Cpt(EpicsSignal, "FirmwareVersion", kind=Kind.config)
+    serial_number = Cpt(EpicsSignal, "SerialNumber", kind=Kind.config)
+    device_temperature = Cpt(EpicsSignal, "DeviceTemperature", kind=Kind.config)
+    ljm_version = Cpt(EpicsSignal, "LJMVersion", kind=Kind.config)
+    driver_version = Cpt(EpicsSignal, "DriverVersion", kind=Kind.config)
+    last_error_message = Cpt(EpicsSignal, "LastErrorMessage", kind=Kind.config)
+    poll_sleep_ms = Cpt(EpicsSignal, "PollSleepMS", kind=Kind.config)
+    poll_time_ms = Cpt(EpicsSignal, "PollTimeMS", kind=Kind.omitted)
+    analog_in_settling_time_all = Cpt(EpicsSignal, "AiAllSettlingUS", kind=Kind.config)
+    analog_in_resolution_all = Cpt(EpicsSignal, "AiAllResolution", kind=Kind.config)
+    analog_in_sampling_rate = Cpt(EpicsSignal, "AiSamplingRate", kind=Kind.config)
+    device_reset = Cpt(EpicsSignal, "DeviceReset", kind=Kind.omitted)
+
+    # Common sub-devices (all labjacks have 2 analog outputs)
+    # NB: Analog inputs/digital I/Os are on a per-model basis
+    analog_outputs = DCpt(make_analog_outputs(2), kind=(Kind.config | Kind.normal))
+    waveform_generator = Cpt(WaveformGenerator, "")
+
+
+class LabJackT4(LabJackBase):
+    class WaveformDigitizer(WaveformDigitizer):
+        waveforms = DCpt(make_digitizer_waveforms(12), kind="normal")
+
+    analog_inputs = DCpt(make_analog_inputs(12), kind=(Kind.config | Kind.normal))
+    digital_ios = DCpt(make_digital_ios(16), kind=(Kind.config | Kind.normal))
+    waveform_digitizer = Cpt(WaveformDigitizer, "")
+    
+
 class LabJackT7(LabJackBase):
     class WaveformDigitizer(WaveformDigitizer):
         waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
 
     analog_inputs = DCpt(make_analog_inputs(14), kind=(Kind.config | Kind.normal))
-    analog_outputs = DCpt(make_analog_outputs(2), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(23), kind=(Kind.config | Kind.normal))
+    waveform_digitizer = Cpt(WaveformDigitizer, "")
+    
+class LabJackT7Pro(LabJackBase):
+    class WaveformDigitizer(WaveformDigitizer):
+        waveforms = DCpt(make_digitizer_waveforms(14), kind="normal")
+
+    analog_inputs = DCpt(make_analog_inputs(14), kind=(Kind.config | Kind.normal))
+    digital_ios = DCpt(make_digital_ios(23), kind=(Kind.config | Kind.normal))
+    waveform_digitizer = Cpt(WaveformDigitizer, "")
+
+
+class LabJackT8(LabJackBase):
+    class WaveformDigitizer(WaveformDigitizer):
+        waveforms = DCpt(make_digitizer_waveforms(8), kind="normal")
+
+    analog_inputs = DCpt(make_analog_inputs(8), kind=(Kind.config | Kind.normal))
+    digital_ios = DCpt(make_digital_ios(20), kind=(Kind.config | Kind.normal))
     waveform_digitizer = Cpt(WaveformDigitizer, "")
     

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -29,6 +29,10 @@ class Output(EpicsRecordOutputFields, EpicsRecordDeviceCommonAll):
     pass
 
 
+class BinaryOutput(Output):
+    output_value = None
+
+
 class AnalogInput(Input):
     differential = FCpt(
         EpicsSignal,
@@ -68,7 +72,7 @@ class DigitalIO(Device):
     ch_num: int
 
     input = FCpt(Input, "{prefix}Bi{ch_num}")
-    output = FCpt(Output, "{prefix}Bo{ch_num}")
+    output = FCpt(BinaryOutput, "{prefix}Bo{ch_num}")
     direction = FCpt(EpicsSignal, "{prefix}Bd{ch_num}", kind=Kind.config)
 
     def __init__(self, *args, ch_num, **kwargs):
@@ -124,7 +128,7 @@ def make_digitizer_waveforms(num_ais: int):
     """
     defn = {}
     for n in range(num_ais):
-        defn[f"wf{n}"] = (EpicsSignalRO, f"WaveDigTimeWF{n}", {})
+        defn[f"wf{n}"] = (EpicsSignalRO, f"WaveDigVoltWF{n}", {})
     return defn
 
 
@@ -170,17 +174,17 @@ class WaveformGenerator(Device):
     
     # Waveform specific settings
     user_waveform_0 = Cpt(EpicsSignal, "WaveGenUserWF0", kind=Kind.config)  # config
-    internal_waveform_0 = Cpt(EpicsSignalRO, "WaveGenIntWF0", kind=Kind.omitted)  # omitted
+    internal_waveform_0 = Cpt(EpicsSignalRO, "WaveGenInternalWF0", kind=Kind.omitted)  # omitted
     enable_0 = Cpt(EpicsSignal, "WaveGenEnable0", kind=Kind.config)  # config
     type_0 = Cpt(EpicsSignal, "WaveGenType0", kind=Kind.config)  # config
-    pulse_width_0 = Cpt(EpicsSignal, "WaveGenPulaseWidth0", kind=Kind.config)  # config
+    pulse_width_0 = Cpt(EpicsSignal, "WaveGenPulseWidth0", kind=Kind.config)  # config
     amplitude_0 = Cpt(EpicsSignal, "WaveGenAmplitude0", kind=Kind.config)  # config
     offset_0 = Cpt(EpicsSignal, "WaveGenOffset0", kind=Kind.config)  # config
     user_waveform_1 = Cpt(EpicsSignal, "WaveGenUserWF1", kind=Kind.config)  # config
-    internal_waveform_1 = Cpt(EpicsSignalRO, "WaveGenIntWF1", kind=Kind.omitted)  # omitted
+    internal_waveform_1 = Cpt(EpicsSignalRO, "WaveGenInternalWF1", kind=Kind.omitted)  # omitted
     enable_1 = Cpt(EpicsSignal, "WaveGenEnable1", kind=Kind.config)  # config
     type_1 = Cpt(EpicsSignal, "WaveGenType1", kind=Kind.config)  # config
-    pulse_width_1 = Cpt(EpicsSignal, "WaveGenPulaseWidth1", kind=Kind.config)  # config
+    pulse_width_1 = Cpt(EpicsSignal, "WaveGenPulseWidth1", kind=Kind.config)  # config
     amplitude_1 = Cpt(EpicsSignal, "WaveGenAmplitude1", kind=Kind.config)  # config
     offset_1 = Cpt(EpicsSignal, "WaveGenOffset1", kind=Kind.config)  # config
     
@@ -235,11 +239,11 @@ def make_digital_ios(num_dios: int):
     for n in range(num_dios):
         defn[f"dio{n}"] = (DigitalIO, "", dict(ch_num=n))
     # Add the digital word outputs
-    defn[f"dio"] = (EpicsSignalRO, "DIO", dict(kind=Kind.normal))
-    defn[f"fio"] = (EpicsSignalRO, "FIO", dict(kind=Kind.normal))
-    defn[f"eio"] = (EpicsSignalRO, "EIO", dict(kind=Kind.normal))
-    defn[f"cio"] = (EpicsSignalRO, "CIO", dict(kind=Kind.normal))
-    defn[f"mio"] = (EpicsSignalRO, "MIO", dict(kind=Kind.normal))
+    defn[f"dio"] = (EpicsSignalRO, "DIOIn", dict(kind=Kind.normal))
+    defn[f"fio"] = (EpicsSignalRO, "FIOIn", dict(kind=Kind.normal))
+    defn[f"eio"] = (EpicsSignalRO, "EIOIn", dict(kind=Kind.normal))
+    defn[f"cio"] = (EpicsSignalRO, "CIOIn", dict(kind=Kind.normal))
+    defn[f"mio"] = (EpicsSignalRO, "MIOIn", dict(kind=Kind.normal))
     return defn
 
 
@@ -265,7 +269,7 @@ class LabJackBase(Device):
     # Common sub-devices (all labjacks have 2 analog outputs)
     # NB: Analog inputs/digital I/Os are on a per-model basis
     analog_outputs = DCpt(make_analog_outputs(2), kind=(Kind.config | Kind.normal))
-    waveform_generator = Cpt(WaveformGenerator, "")
+    waveform_generator = Cpt(WaveformGenerator, "", kind=Kind.omitted)
 
 
 class LabJackT4(LabJackBase):
@@ -274,7 +278,7 @@ class LabJackT4(LabJackBase):
 
     analog_inputs = DCpt(make_analog_inputs(12), kind=(Kind.config | Kind.normal))
     digital_ios = DCpt(make_digital_ios(16), kind=(Kind.config | Kind.normal))
-    waveform_digitizer = Cpt(WaveformDigitizer, "")
+    waveform_digitizer = Cpt(WaveformDigitizer, "", kind=Kind.omitted)
     
 
 class LabJackT7(LabJackBase):

--- a/apstools/devices/labjack.py
+++ b/apstools/devices/labjack.py
@@ -1,0 +1,155 @@
+"""Ophyd definitions for Labjack T-series data acquisition devices.
+
+Currently this is limited to the Labjack T7.
+
+These devices are based on the v3.0.0 EPICS module. The EPICS IOC
+database changed significantly from v2 to v3 when the module was
+rewritten to use the LJM library.
+
+"""
+
+from ophyd import Component as Cpt
+from ophyd import Device
+from ophyd import DynamicDeviceComponent as DCpt
+from ophyd import EpicsSignal
+from ophyd import FormattedComponent as FCpt
+from ophyd import Kind
+
+from apstools.synApps import EpicsRecordDeviceCommonAll
+from apstools.synApps import EpicsRecordInputFields
+from apstools.synApps import EpicsRecordOutputFields
+
+
+class Input(EpicsRecordInputFields, EpicsRecordDeviceCommonAll):
+    pass
+
+
+class Output(EpicsRecordOutputFields, EpicsRecordDeviceCommonAll):
+    pass
+
+
+class AnalogInput(Input):
+    differential = FCpt(
+        EpicsSignal,
+        "{self.base_prefix}Diff{self.ch_num}",
+        kind=Kind.config,
+    )
+    high = FCpt(EpicsSignal, "{self.base_prefix}HOPR{self.ch_num}", kind=Kind.config)
+    low = FCpt(EpicsSignal, "{self.base_prefix}LOPR{self.ch_num}", kind=Kind.config)
+    temperature_units = FCpt(
+        EpicsSignal,
+        "{self.base_prefix}TempUnits{self.ch_num}",
+        kind=Kind.config,
+    )
+    resolution = FCpt(EpicsSignal, "{self.base_prefix}Resolution{self.ch_num}", kind=Kind.config)
+    range = FCpt(
+        EpicsSignal,
+        "{self.base_prefix}Range{self.ch_num}",
+        kind=Kind.config,
+    )
+    mode = FCpt(EpicsSignal, "{self.base_prefix}Mode{self.ch_num}", kind=Kind.config)
+    enable = FCpt(EpicsSignal, "{self.base_prefix}Enable{self.ch_num}", kind=Kind.config)
+
+    @property
+    def base_prefix(self):
+        return self.prefix.rstrip("0123456789")
+
+    @property
+    def ch_num(self):
+        return self.prefix[len(self.base_prefix) :]
+
+
+class AnalogOutput(EpicsRecordOutputFields, EpicsRecordDeviceCommonAll):
+    pass
+
+
+class DigitalIO(Device):
+    ch_num: int
+
+    input = FCpt(Input, "{prefix}Bi{ch_num}")
+    output = FCpt(Output, "{prefix}Bo{ch_num}")
+    direction = FCpt(EpicsSignal, "{prefix}Bd{ch_num}", kind=Kind.config)
+
+    def __init__(self, *args, ch_num, **kwargs):
+        self.ch_num = ch_num
+        super().__init__(*args, **kwargs)
+
+
+class LabJackBase(Device):
+    """A labjack T-series data acquisition unit (DAQ).
+
+    This device is meant as a base for specific device subclasses. It
+    does not have any inputs or outputs.
+
+    """
+
+    model_name = Cpt(EpicsSignal, "ModelName", kind=Kind.config)
+    firmware_version = Cpt(EpicsSignal, "FirmwareVersion", kind=Kind.config)
+    serial_number = Cpt(EpicsSignal, "SerialNumber", kind=Kind.config)
+    device_temperature = Cpt(EpicsSignal, "DeviceTemperature", kind=Kind.config)
+    ljm_version = Cpt(EpicsSignal, "LJMVersion", kind=Kind.config)
+    driver_version = Cpt(EpicsSignal, "DriverVersion", kind=Kind.config)
+    last_error_message = Cpt(EpicsSignal, "LastErrorMessage", kind=Kind.config)
+    poll_sleep_ms = Cpt(EpicsSignal, "PollSleepMS", kind=Kind.config)
+    poll_time_ms = Cpt(EpicsSignal, "PollTimeMS", kind=Kind.omitted)
+    analog_in_settling_time_all = Cpt(EpicsSignal, "AiAllSettlingUS", kind=Kind.config)
+    analog_in_resolution_all = Cpt(EpicsSignal, "AiAllResolution", kind=Kind.config)
+    analog_in_sampling_rate = Cpt(EpicsSignal, "AiSamplingRate", kind=Kind.config)
+    device_reset = Cpt(EpicsSignal, "DeviceReset", kind=Kind.omitted)
+
+
+def make_analog_inputs(num_ais: int):
+    """Create a dictionary with analog input device definitions.
+
+    For use with an ophyd DynamicDeviceComponent.
+
+    Parameters
+    ==========
+    num_ais
+      How many analog inputs to create.
+
+    """
+    defn = {}
+    for n in range(num_ais):
+        defn[f"ai{n}"] = (AnalogInput, f"Ai{n}", {})
+    return defn
+
+
+def make_analog_outputs(num_ais: int):
+    """Create a dictionary with analog output device definitions.
+
+    For use with an ophyd DynamicDeviceComponent.
+
+    Parameters
+    ==========
+    num_aos
+      How many analog outputs to create.
+
+    """
+    defn = {}
+    for n in range(num_ais):
+        defn[f"ao{n}"] = (AnalogOutput, f"Ao{n}", {})
+    return defn
+
+
+def make_digital_ios(num_dios: int):
+    """Create a dictionary with digital I/O device definitions.
+
+    For use with an ophyd DynamicDeviceComponent.
+
+    Parameters
+    ==========
+    num_dios
+      How many digital I/Os to create.
+
+    """
+    defn = {}
+    for n in range(num_dios):
+        defn[f"dio{n}"] = (DigitalIO, "", dict(ch_num=n))
+    return defn
+
+
+class LabJackT7(LabJackBase):
+    analog_inputs = DCpt(make_analog_inputs(14), kind=(Kind.config | Kind.normal))
+    analog_outputs = DCpt(make_analog_outputs(2), kind=(Kind.config | Kind.normal))
+    digital_ios = DCpt(make_digital_ios(23), kind=(Kind.config | Kind.normal))

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -39,41 +39,41 @@ def test_base_signals_device():
         "analog_in_settling_time_all",
         "analog_in_resolution_all",
         "analog_in_sampling_rate",
-        'analog_outputs',
-        'analog_outputs.ao0',
-        'analog_outputs.ao0.alarm_severity',
-        'analog_outputs.ao0.alarm_status',
-        'analog_outputs.ao0.description',
-        'analog_outputs.ao0.desired_output_location',
-        'analog_outputs.ao0.device_type',
-        'analog_outputs.ao0.disable_alarm_severity',
-        'analog_outputs.ao0.disable_value',
-        'analog_outputs.ao0.forward_link',
-        'analog_outputs.ao0.new_alarm_severity',
-        'analog_outputs.ao0.new_alarm_status',
-        'analog_outputs.ao0.output_link',
-        'analog_outputs.ao0.output_mode_select',
-        'analog_outputs.ao0.raw_value',
-        'analog_outputs.ao0.scan_disable_input_link_value',
-        'analog_outputs.ao0.scan_disable_value_input_link',
-        'analog_outputs.ao0.scanning_rate',
-        'analog_outputs.ao1',
-        'analog_outputs.ao1.alarm_severity',
-        'analog_outputs.ao1.alarm_status',
-        'analog_outputs.ao1.description',
-        'analog_outputs.ao1.desired_output_location',
-        'analog_outputs.ao1.device_type',
-        'analog_outputs.ao1.disable_alarm_severity',
-        'analog_outputs.ao1.disable_value',
-        'analog_outputs.ao1.forward_link',
-        'analog_outputs.ao1.new_alarm_severity',
-        'analog_outputs.ao1.new_alarm_status',
-        'analog_outputs.ao1.output_link',
-        'analog_outputs.ao1.output_mode_select',
-        'analog_outputs.ao1.raw_value',
-        'analog_outputs.ao1.scan_disable_input_link_value',
-        'analog_outputs.ao1.scan_disable_value_input_link',
-        'analog_outputs.ao1.scanning_rate',
+        "analog_outputs",
+        "analog_outputs.ao0",
+        "analog_outputs.ao0.alarm_severity",
+        "analog_outputs.ao0.alarm_status",
+        "analog_outputs.ao0.description",
+        "analog_outputs.ao0.desired_output_location",
+        "analog_outputs.ao0.device_type",
+        "analog_outputs.ao0.disable_alarm_severity",
+        "analog_outputs.ao0.disable_value",
+        "analog_outputs.ao0.forward_link",
+        "analog_outputs.ao0.new_alarm_severity",
+        "analog_outputs.ao0.new_alarm_status",
+        "analog_outputs.ao0.output_link",
+        "analog_outputs.ao0.output_mode_select",
+        "analog_outputs.ao0.raw_value",
+        "analog_outputs.ao0.scan_disable_input_link_value",
+        "analog_outputs.ao0.scan_disable_value_input_link",
+        "analog_outputs.ao0.scanning_rate",
+        "analog_outputs.ao1",
+        "analog_outputs.ao1.alarm_severity",
+        "analog_outputs.ao1.alarm_status",
+        "analog_outputs.ao1.description",
+        "analog_outputs.ao1.desired_output_location",
+        "analog_outputs.ao1.device_type",
+        "analog_outputs.ao1.disable_alarm_severity",
+        "analog_outputs.ao1.disable_value",
+        "analog_outputs.ao1.forward_link",
+        "analog_outputs.ao1.new_alarm_severity",
+        "analog_outputs.ao1.new_alarm_status",
+        "analog_outputs.ao1.output_link",
+        "analog_outputs.ao1.output_mode_select",
+        "analog_outputs.ao1.raw_value",
+        "analog_outputs.ao1.scan_disable_input_link_value",
+        "analog_outputs.ao1.scan_disable_value_input_link",
+        "analog_outputs.ao1.scanning_rate",
     ]
     assert sorted(t7.configuration_attrs) == sorted(cfg_names)
 
@@ -126,7 +126,6 @@ ao_params = [
     (labjack.LabJackT7Pro, 2),
     (labjack.LabJackT8, 2),
 ]
-
 
 
 @pytest.mark.parametrize("LabJackDevice,num_aos", ao_params)
@@ -244,12 +243,34 @@ def test_waveform_generator():
     generator = labjack.WaveformGenerator("LabJackT7_1:", name="labjack")
     assert not generator.connected
     # Check read attrs
-    read_attrs = ["frequency", "dwell", "dwell_actual", "total_time", "user_time_waveform",
-                  "internal_time_waveform", ]
+    read_attrs = [
+        "frequency",
+        "dwell",
+        "dwell_actual",
+        "total_time",
+        "user_time_waveform",
+        "internal_time_waveform",
+    ]
     for attr in read_attrs:
         assert attr in generator.read_attrs
     # Check read attrs
-    cfg_attrs = ["external_trigger", "external_clock", "continuous", "num_points", "user_waveform_0", "enable_0", "type_0", "pulse_width_0", "amplitude_0", "offset_0", "user_waveform_1", "enable_1", "type_1", "pulse_width_1", "amplitude_1", "offset_1"]
+    cfg_attrs = [
+        "external_trigger",
+        "external_clock",
+        "continuous",
+        "num_points",
+        "user_waveform_0",
+        "enable_0",
+        "type_0",
+        "pulse_width_0",
+        "amplitude_0",
+        "offset_0",
+        "user_waveform_1",
+        "enable_1",
+        "type_1",
+        "pulse_width_1",
+        "amplitude_1",
+        "offset_1",
+    ]
     for attr in cfg_attrs:
         assert attr in generator.configuration_attrs
-        

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -131,9 +131,6 @@ def test_digital_dios(LabJackDevice, num_dios):
         dio = getattr(device.digital_ios, f"dio{n}")
         assert isinstance(dio, labjack.DigitalIO)
     # Check read attrs
-    from pprint import pprint
-
-    pprint(list(device.hints["fields"]))
     read_attrs = ["output.desired_value", "output.output_value", "input.final_value"]
     for n in range(num_dios):
         for attr in read_attrs:
@@ -151,3 +148,22 @@ def test_digital_dios(LabJackDevice, num_dios):
         for attr in hinted_attrs:
             full_attr = f"labjack_T_digital_ios_dio{n}_{attr}"
             assert full_attr in device.hints["fields"]
+
+
+
+@pytest.mark.parametrize("LabJackDevice,num_dios", dio_params)
+def test_digital_words(LabJackDevice, num_dios):
+    """Test analog inputs for different device types."""
+    device = LabJackDevice(PV_PREFIX, name="labjack_T")
+    assert not device.connected
+    assert hasattr(device, "digital_ios")
+    # Check that the individual digital word outputs were created
+    assert hasattr(device.digital_ios, f"dio")
+    assert hasattr(device.digital_ios, f"fio")
+    assert hasattr(device.digital_ios, f"eio")
+    assert hasattr(device.digital_ios, f"cio")
+    assert hasattr(device.digital_ios, f"mio")
+    # Check read attrs
+    read_attrs = ["dio", "eio", "fio", "mio", "cio"]
+    for attr in read_attrs:
+        assert f"digital_ios.{attr}" in device.read_attrs

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -39,6 +39,23 @@ def test_base_signals_device():
         "analog_in_settling_time_all",
         "analog_in_resolution_all",
         "analog_in_sampling_rate",
+        'waveform_generator',
+        'waveform_generator.amplitude_0',
+        'waveform_generator.amplitude_1',
+        'waveform_generator.continuous',
+        'waveform_generator.enable_0',
+        'waveform_generator.enable_1',
+        'waveform_generator.external_clock',
+        'waveform_generator.external_trigger',
+        'waveform_generator.num_points',
+        'waveform_generator.offset_0',
+        'waveform_generator.offset_1',
+        'waveform_generator.pulse_width_0',
+        'waveform_generator.pulse_width_1',
+        'waveform_generator.type_0',
+        'waveform_generator.type_1',
+        'waveform_generator.user_waveform_0',
+        'waveform_generator.user_waveform_1',
     ]
     assert sorted(t7.configuration_attrs) == sorted(cfg_names)
 
@@ -192,3 +209,18 @@ def test_waveform_digitizer_waveforms(LabJackDevice, num_ais):
     for n in range(num_ais):
         assert hasattr(digitizer.waveforms, f"wf{n}")
         assert f"waveform_digitizer.waveforms.wf{n}" in device.read_attrs
+
+
+def test_waveform_generator():
+    generator = labjack.WaveformGenerator("LabJackT7_1:", name="labjack")
+    assert not generator.connected
+    # Check read attrs
+    read_attrs = ["frequency", "dwell", "dwell_actual", "total_time", "user_time_waveform",
+                  "internal_time_waveform", ]
+    for attr in read_attrs:
+        assert attr in generator.read_attrs
+    # Check read attrs
+    cfg_attrs = ["external_trigger", "external_clock", "continuous", "num_points", "user_waveform_0", "enable_0", "type_0", "pulse_width_0", "amplitude_0", "offset_0", "user_waveform_1", "enable_1", "type_1", "pulse_width_1", "amplitude_1", "offset_1"]
+    for attr in cfg_attrs:
+        assert attr in generator.configuration_attrs
+        

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -150,7 +150,6 @@ def test_digital_dios(LabJackDevice, num_dios):
             assert full_attr in device.hints["fields"]
 
 
-
 @pytest.mark.parametrize("LabJackDevice,num_dios", dio_params)
 def test_digital_words(LabJackDevice, num_dios):
     """Test analog inputs for different device types."""
@@ -167,3 +166,29 @@ def test_digital_words(LabJackDevice, num_dios):
     read_attrs = ["dio", "eio", "fio", "mio", "cio"]
     for attr in read_attrs:
         assert f"digital_ios.{attr}" in device.read_attrs
+
+
+def test_waveform_digitizer():
+    digitizer = labjack.WaveformDigitizer("LabJackT7_1:", name="labjack")
+    assert not digitizer.connected
+    # Check read attrs
+    read_attrs = ["timebase_waveform", "dwell_actual", "total_time"]
+    for attr in read_attrs:
+        assert attr in digitizer.read_attrs
+    # Check read attrs
+    cfg_attrs = ["num_points", "first_chan", "num_chans", "dwell", "resolution", "settling_time", "auto_restart"]
+    for attr in cfg_attrs:
+        assert attr in digitizer.configuration_attrs
+
+
+@pytest.mark.parametrize("LabJackDevice,num_ais", ai_params)
+def test_waveform_digitizer_waveforms(LabJackDevice, num_ais):
+    """Verify that the waveform digitizer is created for each LabJack."""
+    device = LabJackDevice(PV_PREFIX, name="labjack_T")
+    assert hasattr(device, "waveform_digitizer")
+    digitizer = device.waveform_digitizer
+    assert hasattr(digitizer, "waveforms")
+    # Check that the individual waveform signals are present
+    for n in range(num_ais):
+        assert hasattr(digitizer.waveforms, f"wf{n}")
+        assert f"waveform_digitizer.waveforms.wf{n}" in device.read_attrs

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -206,11 +206,11 @@ def test_digital_words(LabJackDevice, num_dios):
     assert not device.connected
     assert hasattr(device, "digital_ios")
     # Check that the individual digital word outputs were created
-    assert hasattr(device.digital_ios, f"dio")
-    assert hasattr(device.digital_ios, f"fio")
-    assert hasattr(device.digital_ios, f"eio")
-    assert hasattr(device.digital_ios, f"cio")
-    assert hasattr(device.digital_ios, f"mio")
+    assert hasattr(device.digital_ios, "dio")
+    assert hasattr(device.digital_ios, "fio")
+    assert hasattr(device.digital_ios, "eio")
+    assert hasattr(device.digital_ios, "cio")
+    assert hasattr(device.digital_ios, "mio")
     # Check read attrs
     read_attrs = ["dio", "eio", "fio", "mio", "cio"]
     for attr in read_attrs:

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -56,6 +56,41 @@ def test_base_signals_device():
         'waveform_generator.type_1',
         'waveform_generator.user_waveform_0',
         'waveform_generator.user_waveform_1',
+        'analog_outputs',
+        'analog_outputs.ao0',
+        'analog_outputs.ao0.alarm_severity',
+        'analog_outputs.ao0.alarm_status',
+        'analog_outputs.ao0.description',
+        'analog_outputs.ao0.desired_output_location',
+        'analog_outputs.ao0.device_type',
+        'analog_outputs.ao0.disable_alarm_severity',
+        'analog_outputs.ao0.disable_value',
+        'analog_outputs.ao0.forward_link',
+        'analog_outputs.ao0.new_alarm_severity',
+        'analog_outputs.ao0.new_alarm_status',
+        'analog_outputs.ao0.output_link',
+        'analog_outputs.ao0.output_mode_select',
+        'analog_outputs.ao0.raw_value',
+        'analog_outputs.ao0.scan_disable_input_link_value',
+        'analog_outputs.ao0.scan_disable_value_input_link',
+        'analog_outputs.ao0.scanning_rate',
+        'analog_outputs.ao1',
+        'analog_outputs.ao1.alarm_severity',
+        'analog_outputs.ao1.alarm_status',
+        'analog_outputs.ao1.description',
+        'analog_outputs.ao1.desired_output_location',
+        'analog_outputs.ao1.device_type',
+        'analog_outputs.ao1.disable_alarm_severity',
+        'analog_outputs.ao1.disable_value',
+        'analog_outputs.ao1.forward_link',
+        'analog_outputs.ao1.new_alarm_severity',
+        'analog_outputs.ao1.new_alarm_status',
+        'analog_outputs.ao1.output_link',
+        'analog_outputs.ao1.output_mode_select',
+        'analog_outputs.ao1.raw_value',
+        'analog_outputs.ao1.scan_disable_input_link_value',
+        'analog_outputs.ao1.scan_disable_value_input_link',
+        'analog_outputs.ao1.scanning_rate',
     ]
     assert sorted(t7.configuration_attrs) == sorted(cfg_names)
 
@@ -66,7 +101,11 @@ def test_base_signals_device():
 
 
 ai_params = [
+    # (model, number of analog inputs)
+    (labjack.LabJackT4, 12),
     (labjack.LabJackT7, 14),
+    (labjack.LabJackT7Pro, 14),
+    (labjack.LabJackT8, 8),
 ]
 
 
@@ -81,6 +120,8 @@ def test_analog_inputs(LabJackDevice, num_ais):
         assert hasattr(device.analog_inputs, f"ai{n}")
         ai = getattr(device.analog_inputs, f"ai{n}")
         assert isinstance(ai, labjack.AnalogInput)
+    # Make sure there aren't any extra analog inputs
+    assert not hasattr(device.analog_inputs, f"ai{num_ais}")
     # Check read attrs
     read_attrs = ["final_value"]
     for n in range(num_ais):
@@ -96,8 +137,13 @@ def test_analog_inputs(LabJackDevice, num_ais):
 
 
 ao_params = [
+    # (model, number of analog outputs)
+    (labjack.LabJackT4, 2),
     (labjack.LabJackT7, 2),
+    (labjack.LabJackT7Pro, 2),
+    (labjack.LabJackT8, 2),
 ]
+
 
 
 @pytest.mark.parametrize("LabJackDevice,num_aos", ao_params)
@@ -132,7 +178,11 @@ def test_analog_outputs(LabJackDevice, num_aos):
 
 
 dio_params = [
+    # (model, number of digital I/Os)
+    (labjack.LabJackT4, 16),
     (labjack.LabJackT7, 23),
+    (labjack.LabJackT7Pro, 23),
+    (labjack.LabJackT8, 20),
 ]
 
 
@@ -209,6 +259,8 @@ def test_waveform_digitizer_waveforms(LabJackDevice, num_ais):
     for n in range(num_ais):
         assert hasattr(digitizer.waveforms, f"wf{n}")
         assert f"waveform_digitizer.waveforms.wf{n}" in device.read_attrs
+    # Check that no extra waveform signals were created
+    assert not hasattr(digitizer.waveforms, f"wf{num_ais}")
 
 
 def test_waveform_generator():

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -1,0 +1,153 @@
+"""Test the Labjack T-series data acquisition device support
+
+Hardware is not available so test with best efforts
+
+"""
+import pytest
+
+from ...tests import IOC_GP
+from .. import labjack
+
+PV_PREFIX = f"phony:{IOC_GP}LJT7:"
+
+
+@pytest.fixture()
+def labjack_device(request):
+    """Parameterized fixture for creating a Vortex device with difference
+    electronics support.
+
+    """
+    # Figure out which detector we're using
+    device = request.getfixturevalue(request.param)
+    yield device
+
+
+def test_base_signals_device():
+    """Test signals shared by all labjack devices."""
+    t7 = labjack.LabJackBase(PV_PREFIX, name="labjack_T7")
+    assert not t7.connected
+
+    cfg_names = [
+        "model_name",
+        "firmware_version",
+        "serial_number",
+        "device_temperature",
+        "ljm_version",
+        "driver_version",
+        "last_error_message",
+        "poll_sleep_ms",
+        "analog_in_settling_time_all",
+        "analog_in_resolution_all",
+        "analog_in_sampling_rate",
+    ]
+    assert sorted(t7.configuration_attrs) == sorted(cfg_names)
+
+    # List all the components
+    # cpt_names = [
+    # ]
+    # assert sorted(t7.component_names) == sorted(cpt_names)
+
+
+ai_params = [
+    (labjack.LabJackT7, 14),
+]
+
+
+@pytest.mark.parametrize("LabJackDevice,num_ais", ai_params)
+def test_analog_inputs(LabJackDevice, num_ais):
+    """Test analog inputs for different device types."""
+    device = LabJackDevice(PV_PREFIX, name="labjack_T")
+    assert not device.connected
+    assert hasattr(device, "analog_inputs")
+    # Check that the individual AI devices were created
+    for n in range(num_ais):
+        assert hasattr(device.analog_inputs, f"ai{n}")
+        ai = getattr(device.analog_inputs, f"ai{n}")
+        assert isinstance(ai, labjack.AnalogInput)
+    # Check read attrs
+    read_attrs = ["final_value"]
+    for n in range(num_ais):
+        for attr in read_attrs:
+            full_attr = f"analog_inputs.ai{n}.{attr}"
+            assert full_attr in device.read_attrs
+    # Check configuration attrs
+    cfg_attrs = ["differential", "high", "low", "temperature_units", "resolution", "range", "mode", "enable"]
+    for n in range(num_ais):
+        for attr in cfg_attrs:
+            full_attr = f"analog_inputs.ai{n}.{attr}"
+            assert full_attr in device.configuration_attrs
+
+
+ao_params = [
+    (labjack.LabJackT7, 2),
+]
+
+
+@pytest.mark.parametrize("LabJackDevice,num_aos", ao_params)
+def test_analog_outputs(LabJackDevice, num_aos):
+    """Test analog inputs for different device types."""
+    device = LabJackDevice(PV_PREFIX, name="labjack_T")
+    assert not device.connected
+    assert hasattr(device, "analog_outputs")
+    # Check that the individual AI devices were created
+    for n in range(num_aos):
+        assert hasattr(device.analog_outputs, f"ao{n}")
+        ai = getattr(device.analog_outputs, f"ao{n}")
+        assert isinstance(ai, labjack.AnalogOutput)
+    # Check read attrs
+    read_attrs = ["desired_value"]
+    for n in range(num_aos):
+        for attr in read_attrs:
+            full_attr = f"analog_outputs.ao{n}.{attr}"
+            assert full_attr in device.read_attrs
+    # Check configuration attrs
+    cfg_attrs = ["output_mode_select"]
+    for n in range(num_aos):
+        for attr in cfg_attrs:
+            full_attr = f"analog_outputs.ao{n}.{attr}"
+            assert full_attr in device.configuration_attrs
+    # Check hinted attrs
+    hinted_attrs = ["readback_value"]
+    for n in range(num_aos):
+        for attr in hinted_attrs:
+            full_attr = f"labjack_T_analog_outputs_ao{n}_{attr}"
+            assert full_attr in device.hints["fields"]
+
+
+dio_params = [
+    (labjack.LabJackT7, 23),
+]
+
+
+@pytest.mark.parametrize("LabJackDevice,num_dios", dio_params)
+def test_digital_dios(LabJackDevice, num_dios):
+    """Test analog inputs for different device types."""
+    device = LabJackDevice(PV_PREFIX, name="labjack_T")
+    assert not device.connected
+    assert hasattr(device, "digital_ios")
+    # Check that the individual digital I/O devices were created
+    for n in range(num_dios):
+        assert hasattr(device.digital_ios, f"dio{n}")
+        dio = getattr(device.digital_ios, f"dio{n}")
+        assert isinstance(dio, labjack.DigitalIO)
+    # Check read attrs
+    from pprint import pprint
+
+    pprint(list(device.hints["fields"]))
+    read_attrs = ["output.desired_value", "output.output_value", "input.final_value"]
+    for n in range(num_dios):
+        for attr in read_attrs:
+            full_attr = f"digital_ios.dio{n}.{attr}"
+            assert full_attr in device.read_attrs
+    # Check configuration attrs
+    cfg_attrs = ["output.raw_value", "input.raw_value", "direction"]
+    for n in range(num_dios):
+        for attr in cfg_attrs:
+            full_attr = f"digital_ios.dio{n}.{attr}"
+            assert full_attr in device.configuration_attrs
+    # Check hinted attrs
+    hinted_attrs = ["output_readback_value"]
+    for n in range(num_dios):
+        for attr in hinted_attrs:
+            full_attr = f"labjack_T_digital_ios_dio{n}_{attr}"
+            assert full_attr in device.hints["fields"]

--- a/apstools/devices/tests/test_labjack.py
+++ b/apstools/devices/tests/test_labjack.py
@@ -39,23 +39,6 @@ def test_base_signals_device():
         "analog_in_settling_time_all",
         "analog_in_resolution_all",
         "analog_in_sampling_rate",
-        'waveform_generator',
-        'waveform_generator.amplitude_0',
-        'waveform_generator.amplitude_1',
-        'waveform_generator.continuous',
-        'waveform_generator.enable_0',
-        'waveform_generator.enable_1',
-        'waveform_generator.external_clock',
-        'waveform_generator.external_trigger',
-        'waveform_generator.num_points',
-        'waveform_generator.offset_0',
-        'waveform_generator.offset_1',
-        'waveform_generator.pulse_width_0',
-        'waveform_generator.pulse_width_1',
-        'waveform_generator.type_0',
-        'waveform_generator.type_1',
-        'waveform_generator.user_waveform_0',
-        'waveform_generator.user_waveform_1',
         'analog_outputs',
         'analog_outputs.ao0',
         'analog_outputs.ao0.alarm_severity',
@@ -198,7 +181,7 @@ def test_digital_dios(LabJackDevice, num_dios):
         dio = getattr(device.digital_ios, f"dio{n}")
         assert isinstance(dio, labjack.DigitalIO)
     # Check read attrs
-    read_attrs = ["output.desired_value", "output.output_value", "input.final_value"]
+    read_attrs = ["output.desired_value", "input.final_value"]
     for n in range(num_dios):
         for attr in read_attrs:
             full_attr = f"digital_ios.dio{n}.{attr}"
@@ -255,12 +238,6 @@ def test_waveform_digitizer_waveforms(LabJackDevice, num_ais):
     assert hasattr(device, "waveform_digitizer")
     digitizer = device.waveform_digitizer
     assert hasattr(digitizer, "waveforms")
-    # Check that the individual waveform signals are present
-    for n in range(num_ais):
-        assert hasattr(digitizer.waveforms, f"wf{n}")
-        assert f"waveform_digitizer.waveforms.wf{n}" in device.read_attrs
-    # Check that no extra waveform signals were created
-    assert not hasattr(digitizer.waveforms, f"wf{num_ais}")
 
 
 def test_waveform_generator():

--- a/docs/source/api/_devices.rst
+++ b/docs/source/api/_devices.rst
@@ -209,6 +209,11 @@ Other Support
     ~apstools.devices.struck3820.Struck3820
     ~apstools.devices.delay.DG645Delay
     ~apstools.devices.labjack.LabJackBase
+    ~apstools.devices.labjack.LabJackT4
+    ~apstools.devices.labjack.LabJackT7
+    ~apstools.devices.labjack.LabJackT7Pro
+    ~apstools.devices.labjack.LabJackT8
+
 
 Internal Routines
 +++++++++++++++++

--- a/docs/source/api/_devices.rst
+++ b/docs/source/api/_devices.rst
@@ -208,6 +208,7 @@ Other Support
     ~apstools.devices.srs570_preamplifier.SRS570_PreAmplifier
     ~apstools.devices.struck3820.Struck3820
     ~apstools.devices.delay.DG645Delay
+    ~apstools.devices.labjack.LabJackBase
 
 Internal Routines
 +++++++++++++++++
@@ -300,6 +301,12 @@ All Submodules
     :inherited-members:
 
 .. automodule:: apstools.devices.kohzu_monochromator
+    :members:
+    :private-members:
+    :show-inheritance:
+    :inherited-members:
+
+.. automodule:: apstools.devices.labjack
     :members:
     :private-members:
     :show-inheritance:


### PR DESCRIPTION
Fixes  #879.

One note: I created a LabJackBase class and then subclass this for the various T-series devices (e.g. LabJackT4). Makes the code easy to maintain, but docstring don't seem to be inheriting properly on the sphinx autoapi.