### PR TITLE
SR-570 race condition

### DIFF
--- a/apstools/devices/srs570_preamplifier.py
+++ b/apstools/devices/srs570_preamplifier.py
@@ -182,7 +182,7 @@ class SRS570_PreAmplifier(PreamplifierBaseDevice):
     # in the EPICS .db file.  Must cast them to ``float()`` or ``int()``
     # as desired.
     # see: https://github.com/epics-modules/ip/blob/master/ipApp/Db/SR570.db
-    sensitivity_value = Component(GainSignal, "sens_num", kind="config", string=True, put_complete=True)
+    sensitivity_value = Component(GainSignal, "sens_num", kind="config", string=True)
     sensitivity_unit = Component(GainSignal, "sens_unit", kind="config", string=True, put_complete=True)
 
     offset_on = Component(EpicsSignal, "offset_on", kind="config", string=True)

--- a/apstools/devices/srs570_preamplifier.py
+++ b/apstools/devices/srs570_preamplifier.py
@@ -182,8 +182,8 @@ class SRS570_PreAmplifier(PreamplifierBaseDevice):
     # in the EPICS .db file.  Must cast them to ``float()`` or ``int()``
     # as desired.
     # see: https://github.com/epics-modules/ip/blob/master/ipApp/Db/SR570.db
-    sensitivity_value = Component(GainSignal, "sens_num", kind="config", string=True)
-    sensitivity_unit = Component(GainSignal, "sens_unit", kind="config", string=True)
+    sensitivity_value = Component(GainSignal, "sens_num", kind="config", string=True, put_complete=True)
+    sensitivity_unit = Component(GainSignal, "sens_unit", kind="config", string=True, put_complete=True)
 
     offset_on = Component(EpicsSignal, "offset_on", kind="config", string=True)
     offset_sign = Component(EpicsSignal, "offset_sign", kind="config", string=True)


### PR DESCRIPTION
Fixes a race condition where the SR570 pre-amp gets the sensitivity_value set before the sensitivity_unit, ending up at the wrong gain.

If the gain is set to 1 mA/V in the IOC, and you try to set it to e.g. 200 µA/V, you need to set the unit first then the value since "1" is the only valid "mA/V" value:

✓ 1 mA/V -> 1 µA/V -> 200 µA/V
✗ 1 mA/V -> 200 mA/V (corrects to 1 mA/V) -> 1 µA/V

Solved this problem by using ``put_complete=True`` for the *sensitivity_unit* signal.
