### PR TITLE
2M & 4M undulators

### DIFF
--- a/apstools/devices/__init__.py
+++ b/apstools/devices/__init__.py
@@ -18,6 +18,9 @@ from .aps_data_management import DM_WorkflowConnector
 from .aps_machine import ApsMachineParametersDevice
 
 from .aps_undulator import PlanarUndulator
+from .aps_undulator import Revolver_Undulator
+from .aps_undulator import STI_Undulator
+from .aps_undulator import Undulator2M
 
 from .area_detector_support import AD_EpicsFileNameMixin
 from .area_detector_support import AD_FrameType_schemes

--- a/apstools/devices/__init__.py
+++ b/apstools/devices/__init__.py
@@ -21,6 +21,7 @@ from .aps_undulator import PlanarUndulator
 from .aps_undulator import Revolver_Undulator
 from .aps_undulator import STI_Undulator
 from .aps_undulator import Undulator2M
+from .aps_undulator import Undulator4M
 
 from .area_detector_support import AD_EpicsFileNameMixin
 from .area_detector_support import AD_FrameType_schemes

--- a/apstools/devices/aps_undulator.py
+++ b/apstools/devices/aps_undulator.py
@@ -8,6 +8,7 @@ APS undulators (Insertion Devices)
    ~Revolver_Undulator
    ~STI_Undulator
    ~Undulator2M
+   ~Undulator4M
 """
 
 import logging
@@ -191,6 +192,30 @@ class Undulator2M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
     EXAMPLE::
 
         undulator = Undulator2M("S01ID:DSID:", name="undulator")
+    """
+
+    # PVs not found
+    busy = None
+    magnet = None
+    version_plc = None
+    version_hpmu = None
+
+    done = Component(EpicsSignalRO, "BusyM.VAL", kind="omitted")
+    done_value = 0
+
+
+class Undulator4M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
+    """APS 4M Undulator.
+
+    .. index::
+        Ophyd Device; PlanarUndulator
+        Ophyd Device; Undulator4M
+
+    APS Use: 11ID, downstream & upstream.
+
+    EXAMPLE::
+
+        undulator = Undulator4M("S11ID:DSID:", name="undulator")
     """
 
     # PVs not found

--- a/apstools/devices/aps_undulator.py
+++ b/apstools/devices/aps_undulator.py
@@ -9,6 +9,9 @@ APS undulators (Insertion Devices)
    ~STI_Undulator
    ~Undulator2M
    ~Undulator4M
+
+.. note:: The ``ApsUndulator`` and ``ApsUndulatorDual`` device support
+    classes have been removed.  These devices are not used in the APS-U era.
 """
 
 import logging

--- a/apstools/devices/aps_undulator.py
+++ b/apstools/devices/aps_undulator.py
@@ -7,6 +7,7 @@ APS undulators (Insertion Devices)
    ~PlanarUndulator
    ~Revolver_Undulator
    ~STI_Undulator
+   ~Undulator2M
 """
 
 import logging
@@ -166,7 +167,7 @@ class Revolver_Undulator(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, De
 class STI_Undulator(PlanarUndulator):
     """APS Planar Undulator built by STI Optronics.
 
-    .. index:: 
+    .. index::
         Ophyd Device; PlanarUndulator
         Ophyd Device; STI_Undulator
 
@@ -176,6 +177,30 @@ class STI_Undulator(PlanarUndulator):
 
         undulator = STI_Undulator("S04ID:USID:", name="undulator")
     """
+
+
+class Undulator2M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
+    """APS 2M Undulator.
+
+    .. index::
+        Ophyd Device; PlanarUndulator
+        Ophyd Device; Undulator2M
+
+    APS Use: 1ID, downstream.
+
+    EXAMPLE::
+
+        undulator = Undulator2M("S01ID:DSID:", name="undulator")
+    """
+
+    # PVs not found
+    busy = None
+    magnet = None
+    version_plc = None
+    version_hpmu = None
+
+    done = Component(EpicsSignalRO, "BusyM.VAL", kind="omitted")
+    done_value = 0
 
 
 # -----------------------------------------------------------------------------

--- a/apstools/devices/aps_undulator.py
+++ b/apstools/devices/aps_undulator.py
@@ -207,7 +207,7 @@ class Undulator2M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
     done_value = 0
 
 
-class Undulator4M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
+class Undulator4M(Undulator2M):
     """APS 4M Undulator.
 
     .. index::
@@ -220,16 +220,6 @@ class Undulator4M(ID_Spectrum_Mixin, ID_Controls_Mixin, ID_Misc_Mixin, Device):
 
         undulator = Undulator4M("S11ID:DSID:", name="undulator")
     """
-
-    # PVs not found
-    busy = None
-    magnet = None
-    version_plc = None
-    version_hpmu = None
-
-    done = Component(EpicsSignalRO, "BusyM.VAL", kind="omitted")
-    done_value = 0
-
 
 # -----------------------------------------------------------------------------
 # :author:    Pete R. Jemian

--- a/apstools/devices/tests/test_aps_undulator.py
+++ b/apstools/devices/tests/test_aps_undulator.py
@@ -7,15 +7,16 @@ from ..aps_undulator import STI_Undulator
 from ..aps_undulator import Undulator2M
 
 
-@pytest.mark.parametrize(
-    "klass, prefix",
-    [
-        [PlanarUndulator, "PSS:255ID:"],
-        [Undulator2M, "PSS:255ID:"],
-        [Revolver_Undulator, "PSS:255ID:"],
-        [STI_Undulator, "PSS:255ID:"],
-    ],
-)
+TEST_PV_PREFIX = "TEST:PREFIX:"
+TEST_CASES = [
+    [PlanarUndulator, TEST_PV_PREFIX],
+    [Revolver_Undulator, TEST_PV_PREFIX],
+    [STI_Undulator, TEST_PV_PREFIX],
+    [Undulator2M, TEST_PV_PREFIX],
+]
+
+
+@pytest.mark.parametrize("klass, prefix", TEST_CASES)
 def test_set_energy(klass, prefix):
     undulator = instantiate_fake_device(klass, prefix=prefix, name="undulator")
 
@@ -25,15 +26,7 @@ def test_set_energy(klass, prefix):
     assert undulator.start_button.get() == 1
 
 
-@pytest.mark.parametrize(
-    "klass, prefix",
-    [
-        [PlanarUndulator, "PSS:255ID:"],
-        [Undulator2M, "S01ID:DSID:"],
-        [Revolver_Undulator, "S08ID:USID:"],
-        [STI_Undulator, "S04ID:USID:"],
-    ],
-)
+@pytest.mark.parametrize("klass, prefix", TEST_CASES)
 def test_stop_energy(klass, prefix):
     undulator = instantiate_fake_device(klass, prefix=prefix, name="undulator")
 

--- a/apstools/devices/tests/test_aps_undulator.py
+++ b/apstools/devices/tests/test_aps_undulator.py
@@ -2,22 +2,41 @@ import pytest
 from ophyd.sim import instantiate_fake_device
 
 from ..aps_undulator import PlanarUndulator
+from ..aps_undulator import Revolver_Undulator
+from ..aps_undulator import STI_Undulator
+from ..aps_undulator import Undulator2M
 
 
-@pytest.fixture()
-def undulator():
-    undulator = instantiate_fake_device(PlanarUndulator, prefix="PSS:255ID:", name="undulator")
-    return undulator
+@pytest.mark.parametrize(
+    "klass, prefix",
+    [
+        [PlanarUndulator, "PSS:255ID:"],
+        [Undulator2M, "S01ID:DSID:"],
+        [Revolver_Undulator, "S08ID:USID:"],
+        [STI_Undulator, "S04ID:USID:"],
+    ],
+)
+def test_set_energy(klass, prefix):
+    undulator = instantiate_fake_device(klass, prefix=prefix, name="undulator")
 
-
-def test_set_energy(undulator):
     assert undulator.start_button.get() == 0
     undulator.energy.set(5)
     assert undulator.energy.setpoint.get() == 5
     assert undulator.start_button.get() == 1
 
 
-def test_stop_energy(undulator):
+@pytest.mark.parametrize(
+    "klass, prefix",
+    [
+        [PlanarUndulator, "PSS:255ID:"],
+        [Undulator2M, "S01ID:DSID:"],
+        [Revolver_Undulator, "S08ID:USID:"],
+        [STI_Undulator, "S04ID:USID:"],
+    ],
+)
+def test_stop_energy(klass, prefix):
+    undulator = instantiate_fake_device(klass, prefix=prefix, name="undulator")
+
     assert undulator.stop_button.get() == 0
     undulator.stop()
     assert undulator.stop_button.get() == 1

--- a/apstools/devices/tests/test_aps_undulator.py
+++ b/apstools/devices/tests/test_aps_undulator.py
@@ -11,9 +11,9 @@ from ..aps_undulator import Undulator2M
     "klass, prefix",
     [
         [PlanarUndulator, "PSS:255ID:"],
-        [Undulator2M, "S01ID:DSID:"],
-        [Revolver_Undulator, "S08ID:USID:"],
-        [STI_Undulator, "S04ID:USID:"],
+        [Undulator2M, "PSS:255ID:"],
+        [Revolver_Undulator, "PSS:255ID:"],
+        [STI_Undulator, "PSS:255ID:"],
     ],
 )
 def test_set_energy(klass, prefix):

--- a/apstools/devices/tests/test_aps_undulator.py
+++ b/apstools/devices/tests/test_aps_undulator.py
@@ -5,6 +5,7 @@ from ..aps_undulator import PlanarUndulator
 from ..aps_undulator import Revolver_Undulator
 from ..aps_undulator import STI_Undulator
 from ..aps_undulator import Undulator2M
+from ..aps_undulator import Undulator4M
 
 
 TEST_PV_PREFIX = "TEST:PREFIX:"
@@ -13,6 +14,7 @@ TEST_CASES = [
     [Revolver_Undulator, TEST_PV_PREFIX],
     [STI_Undulator, TEST_PV_PREFIX],
     [Undulator2M, TEST_PV_PREFIX],
+    [Undulator4M, TEST_PV_PREFIX],
 ]
 
 

--- a/apstools/tests/__init__.py
+++ b/apstools/tests/__init__.py
@@ -9,7 +9,7 @@ from ophyd.signal import EpicsSignalBase
 IOC_GP = "gp:"  # general purpose IOC: motors, scalers, slits, ...
 IOC_AD = "ad:"  # ADSimDetector IOC
 
-MASTER_TIMEOUT = 3
+MASTER_TIMEOUT = 10
 MAX_TESTING_RETRIES = 3
 SHORT_DELAY_FOR_EPICS_IOC_DATABASE_PROCESSING = 2.0 / 60  # two 60Hz clock cycles
 

--- a/docs/source/api/_devices.rst
+++ b/docs/source/api/_devices.rst
@@ -18,6 +18,7 @@ See these categories:
 * :ref:`devices.aps_support`
 * :ref:`devices.area_detector`
 * :ref:`devices.flyers`
+* :ref:`devices.insertion_devices`
 * :ref:`devices.motors`
 * :ref:`devices.scalers`
 * :ref:`devices.shutters`
@@ -103,6 +104,22 @@ Fly Scan Support
         ~apstools.devices.flyer_motor_scaler.ScalerMotorFlyer
 
 ``ScalerMotorFlyer()`` support withdrawn pending issue #763.
+
+.. _devices.insertion_devices:
+
+Insertion Devices
++++++++++++++++++
+
+.. autosummary::
+
+    ~apstools.devices.aps_undulator.PlanarUndulator
+    ~apstools.devices.aps_undulator.Revolver_Undulator
+    ~apstools.devices.aps_undulator.STI_Undulator
+    ~apstools.devices.aps_undulator.Undulator2M
+    ~apstools.devices.aps_undulator.Undulator4M
+
+.. note:: The ``ApsUndulator`` and ``ApsUndulatorDual`` device support
+    classes have been removed.  These devices are not used in the APS-U era.
 
 .. _devices.motors:
 


### PR DESCRIPTION
- close #975
- close #976

NOTE: 2M & 4M -- No PV for Done Moving, rely on Busy and set `done_value=0` instead.

@cooleyv
@cpchuang