### PR TITLE
Fix typo in PV name for synApps SaveData() class

### DIFF
--- a/apstools/synApps/save_data.py
+++ b/apstools/synApps/save_data.py
@@ -49,7 +49,7 @@ class SaveData(Device):
     comment2 = Component(EpicsSignal, "comment2", string=True, kind="config")
     write_1D_each_point = Component(EpicsSignal, "realTime1D", string=True, kind="config")
     max_retries = Component(EpicsSignal, "maxAllowedRetries", kind="config")
-    retry_wait_s = Component(EpicsSignal, "retryWaitinSecs", kind="config")
+    retry_wait_s = Component(EpicsSignal, "retryWaitInSecs", kind="config")
 
     full_path_name = Component(EpicsSignalRO, "fullPathName", string=True, kind="config")
     full_name = Component(EpicsSignalRO, "fileName", string=True, kind="normal")


### PR DESCRIPTION
- close #1003
@FabricioSMarin - Thanks for reporting this!