### PR TITLE
allow package import even if databroker v2.0+ is installed in environment

### DIFF
--- a/apstools/devices/aps_data_management.py
+++ b/apstools/devices/aps_data_management.py
@@ -35,8 +35,6 @@ from ophyd import Component
 from ophyd import Device
 from ophyd import Signal
 
-from ..utils import run_in_thread
-
 logger = logging.getLogger(__name__)
 
 NOT_AVAILABLE = "-n/a-"
@@ -191,6 +189,8 @@ class DM_WorkflowConnector(Device):
         The reporting process will continue until the workflow ends or the
         timeout period is exceeded.  It does not affect the actual workflow.
         """
+        from ..utils import run_in_thread
+
         if workflow == "":
             workflow = self.workflow.get()
         else:

--- a/apstools/utils/_core.py
+++ b/apstools/utils/_core.py
@@ -1,25 +1,11 @@
 from enum import Enum
 
-import databroker._drivers.mongo_normalized
-import databroker._drivers.msgpack
-import intake
 import pandas
 import pyRestTable
 
 FIRST_DATA = "1995-01-01"
 LAST_DATA = "2100-12-31"
 
-CATALOG_CLASSES = (
-    databroker.Broker,
-    databroker._drivers.mongo_normalized.BlueskyMongoCatalog,
-    databroker._drivers.msgpack.BlueskyMsgpackCatalog,
-    intake.Catalog,
-)
-MONGO_CATALOG_CLASSES = (
-    databroker.Broker,
-    databroker._drivers.mongo_normalized.BlueskyMongoCatalog,
-    # intake.Catalog,
-)
 MAX_EPICS_STRINGOUT_LENGTH = 40
 
 

--- a/apstools/utils/catalog.py
+++ b/apstools/utils/catalog.py
@@ -16,14 +16,11 @@ Working with databroker catalogs
 
 import logging
 
-import databroker
-import databroker._drivers.mongo_normalized
-import databroker._drivers.msgpack
+# import databroker
 import databroker.queries
 import pandas as pd
 import pyRestTable
 
-from ._core import CATALOG_CLASSES
 from .list_runs import getRunData
 from .profile_support import getDefaultNamespace
 from .profile_support import ipython_shell_namespace
@@ -191,6 +188,12 @@ def getDefaultDatabase():
 
     (new in release 1.4.0)
     """
+    from databroker import Broker
+    from databroker._drivers.mongo_normalized import BlueskyMongoCatalog
+    from databroker._drivers.msgpack import BlueskyMsgpackCatalog
+    from intake import Catalog
+
+    CATALOG_CLASSES = (Broker, BlueskyMongoCatalog, BlueskyMsgpackCatalog, Catalog)
     # look through the console namespace
     g = ipython_shell_namespace()
     if len(g) == 0:

--- a/apstools/utils/catalog.py
+++ b/apstools/utils/catalog.py
@@ -16,8 +16,6 @@ Working with databroker catalogs
 
 import logging
 
-# import databroker
-import databroker.queries
 import pandas as pd
 import pyRestTable
 
@@ -390,6 +388,9 @@ def quantify_md_key_use(
         tune_mr                    1
         ========================== =====
     """
+    from databroker import catalog
+    from databroker.queries import TimeRange
+
     key = key or "plan_name"
     catalog_name = catalog_name or "mongodb_config"
     query = query or {}
@@ -397,8 +398,8 @@ def quantify_md_key_use(
     until = until or "2100-12-31"
 
     cat = (
-        (db or databroker.catalog[catalog_name])
-        .v2.search(databroker.queries.TimeRange(since=since, until=until))
+        (db or catalog[catalog_name])
+        .v2.search(TimeRange(since=since, until=until))
         .search(query)
     )
 

--- a/apstools/utils/list_runs.py
+++ b/apstools/utils/list_runs.py
@@ -27,7 +27,6 @@ import databroker.queries
 
 from ._core import FIRST_DATA
 from ._core import LAST_DATA
-from ._core import MONGO_CATALOG_CLASSES
 from ._core import TableStyle
 from .query import db_query
 
@@ -385,6 +384,10 @@ class ListRuns:
                         exc,
                     )
         else:
+            from databroker import Broker
+            from databroker._drivers.mongo_normalized import BlueskyMongoCatalog
+
+            MONGO_CATALOG_CLASSES = (Broker, BlueskyMongoCatalog)
             if isinstance(cat, MONGO_CATALOG_CLASSES) and self.sortby == "time":
                 if self.reverse:
                     # the default rendering: from MongoDB in reverse time order

--- a/apstools/utils/list_runs.py
+++ b/apstools/utils/list_runs.py
@@ -20,11 +20,6 @@ import typing
 import warnings
 from collections import defaultdict
 
-import databroker
-import databroker._drivers.mongo_normalized
-import databroker._drivers.msgpack
-import databroker.queries
-
 from ._core import FIRST_DATA
 from ._core import LAST_DATA
 from ._core import TableStyle
@@ -344,11 +339,13 @@ class ListRuns:
 
     def _apply_search_filters(self):
         """Search for runs from the catalog."""
+        from databroker.queries import TimeRange
+
         since = self.since or FIRST_DATA
         until = self.until or LAST_DATA
         self._check_cat()
         query = {}
-        query.update(databroker.queries.TimeRange(since=since, until=until))
+        query.update(TimeRange(since=since, until=until))
         query.update(self.query or {})
         cat = self.cat.v2.search(query)
         return cat
@@ -589,12 +586,13 @@ def summarize_runs(since=None, db=None):
         Instance of ``databroker.Broker()``
         (default: ``db`` from the IPython shell)
     """
+    from databroker.queries import TimeRange
     from . import ipython_shell_namespace
 
     db = db or ipython_shell_namespace()["db"]
     # no APS X-ray experiment data before 1995!
     since = since or "1995"
-    cat = db.v2.search(databroker.queries.TimeRange(since=since))
+    cat = db.v2.search(TimeRange(since=since))
     plans = defaultdict(list)
     t0 = time.time()
     for n, uid in enumerate(cat):

--- a/apstools/utils/misc.py
+++ b/apstools/utils/misc.py
@@ -40,7 +40,6 @@ from collections import OrderedDict
 from collections import defaultdict
 from functools import wraps
 
-import databroker
 import ophyd
 import pyRestTable
 from bluesky import plan_stubs as bps
@@ -329,6 +328,8 @@ def replay(headers, callback=None, sort=True):
 
     (new in apstools release 1.1.11)
     """
+    from databroker import Header
+
     # fmt: off
     callback = callback or ipython_shell_namespace().get(
         "bec",  # get from IPython shell
@@ -363,7 +364,7 @@ def replay(headers, callback=None, sort=True):
     # fmt: on
 
     for h in sorted(runs, key=sorter):
-        if not isinstance(h, databroker.Header):
+        if not isinstance(h, Header):
             # fmt: off
             raise TypeError(
                 f"Must be a databroker Header: received: {type(h)}: |{h}|"

--- a/apstools/utils/query.py
+++ b/apstools/utils/query.py
@@ -7,8 +7,6 @@ Searching databroker catalogs
    ~db_query
 """
 
-import databroker
-
 from ._core import FIRST_DATA
 from ._core import LAST_DATA
 
@@ -37,6 +35,7 @@ def db_query(db, query):
 
        :func:`databroker.catalog.search`
     """
+    from databroker.queries import TimeRange
 
     if query is None:
         return db
@@ -50,11 +49,8 @@ def db_query(db, query):
         if not until:
             until = LAST_DATA
 
-        # fmt: off
-        _db = db.v2.search(
-            databroker.queries.TimeRange(since=since, until=until)
-        )
-        # fmt: on
+        time_span = TimeRange(since=since, until=until)
+        _db = db.v2.search(time_span)
     else:
         _db = db
 


### PR DESCRIPTION
- close #1026

Changes should be transparent to current operations but should allow development and testing (such as with [`ophyd-async`](https://github.com/bluesky/ophyd-async)) if databroker is installed.