### PR TITLE
Added support for PyDevice controlled items and generalized White Beam Aperture (aka HHL slits) support

### DIFF
--- a/apstools/devices/__init__.py
+++ b/apstools/devices/__init__.py
@@ -49,6 +49,7 @@ from .area_detector_support import SimDetectorCam_V34
 from .area_detector_support import SingleTrigger_V34
 from .area_detector_support import ensure_AD_plugin_primed
 
+from .avs_filters import AVSfilters
 
 from .axis_tuner import AxisTunerException
 from .axis_tuner import AxisTunerMixin
@@ -72,7 +73,13 @@ from .eurotherm_2216e import Eurotherm2216e
 # from .flyer_motor_scaler import _SMFlyer_Step_1
 # from .flyer_motor_scaler import _SMFlyer_Step_2
 # from .flyer_motor_scaler import _SMFlyer_Step_3
+
+from .hhl_apertures import HHLAperture
+
 from .hhl_slits import HHLSlits
+
+from .jj_transfocators import JJtransfocator1x, JJtransfocator2x
+from .jj_transfocators import JJtransfocator1xZ, JJtransfocator2xZ
 
 from .kohzu_monochromator import KohzuSeqCtl_Monochromator
 

--- a/apstools/devices/avs_filters.py
+++ b/apstools/devices/avs_filters.py
@@ -1,0 +1,73 @@
+"""
+12-bank Filters from A-V-S
+
+Device uses PyDevice for attenuation calculation and filter configuration
+
+    Parameters
+    ==========
+    prefix:
+      EPICS prefix required to communicate with filter IOC, ex: "100idPyFilter:FL2:"
+    translation_motor:
+      The motor record PV controlling the lateral translation of the filter system
+
+"""
+
+
+from ophyd import Component as Cpt
+from ophyd import FormattedComponent as FCpt
+from ophyd import Device
+from ophyd import EpicsSignal, EpicsSignalRO
+from ophyd import EpicsMotor
+from ophyd import PVPositioner
+
+
+class filter_index(PVPositioner):
+    """
+    filter index; increasing index, increasing attenuation
+    """
+    readback = Cpt(EpicsSignalRO, 'sortedIndex_RBV')
+    setpoint = Cpt(EpicsSignal, 'sortedIndex')
+    done = Cpt(EpicsSignalRO, 'filterBusy')
+
+class filter_atten(PVPositioner):
+    """
+    filter attenuation positioner
+    """
+    readback = Cpt(EpicsSignalRO, 'attenuation_actual')
+    setpoint = Cpt(EpicsSignal, 'attenuation')
+    done = Cpt(EpicsSignalRO, 'filterBusy')
+
+class filter_trans(PVPositioner):
+    """
+    filter transmission positioner
+    """
+    readback = Cpt(EpicsSignalRO, 'transmission_RBV')
+    setpoint = Cpt(EpicsSignal, 'transmission')
+    done = Cpt(EpicsSignalRO, 'filterBusy')
+
+class AVSfilters(Device):
+
+    def __init__(
+        self,
+        prefix: str,
+        translation_motor: str,
+        *args,
+        **kwargs,
+    ):    
+    
+        self._translation = translation_motor
+    
+        super().__init__(prefix, *args, **kwargs)
+
+    
+    index = FCpt(filter_index, "{prefix}")
+    attenuation = FCpt(filter_atten, "{prefix}")
+    transmission = FCpt(filter_trans, "{prefix}")
+    translation = FCpt(EpicsMotor, "{_translation}", labels={'motors'})
+    
+    binary_crl1_config = Cpt(EpicsSignalRO, "filterConfig", kind="hinted")
+    bw_crl1_config = Cpt(EpicsSignalRO, "filterConfig_BW")
+    rbv_crl1_config = Cpt(EpicsSignalRO, "filterConfig_RBV", kind="hinted")
+    inMask_config = Cpt(EpicsSignalRO, "inMask_RBV", kind="config")
+    outMask_config = Cpt(EpicsSignalRO, "outMask_RBV", kind="config")
+

--- a/apstools/devices/hhl_apertures.py
+++ b/apstools/devices/hhl_apertures.py
@@ -1,0 +1,64 @@
+from ophyd import Component as Cpt
+from ophyd import Device
+from ophyd import FormattedComponent as FCpt
+from ophyd import EpicsMotor
+
+
+class HHLAperture(Device):
+    """
+    High Heat Load Aperture.
+
+    There are no independent parts to move, so each axis only has center and size.
+
+    Based on the Variable Mass Aperture Slits support in OPTICS module.
+
+	Similar to HHL_slits but for beamlines that dont follow 25ID nomenclature.
+
+    Parameters
+    ==========
+    prefix:
+      EPICS prefix required to communicate with HHL Slit IOC, ex: "9ida:SL1:"
+    pitch_motor:
+      The motor record PV controlling the real pitch motor, ex "9ida:CR9A1:m3"
+    yaw_motor:
+      The motor record PV controlling the real yaw motor, ex "9ida:CR9A1:m4"
+    horizontal_motor:
+      The motor record PV controlling the real horizontal motor, ex: "9ida:CR9A1:m1"
+    diagonal_motor:
+      The motor record PV controlling the real diagonal motor, ex: "9ida:CR9A1:m2"
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        pitch_motor: str,
+        yaw_motor: str,
+        horizontal_motor: str,
+        diagonal_motor: str,
+        *args,
+        **kwargs,
+    ):
+#        # Determine the prefix for the motors
+#        pieces = prefix.strip(":").split(":")
+#        self.motor_prefix = ":".join(pieces[:-1])
+
+        self._pitch_motor = pitch_motor
+        self._yaw_motor = yaw_motor
+        self._horizontal_motor = horizontal_motor
+        self._diagonal_motor = diagonal_motor
+
+        super().__init__(prefix, *args, **kwargs)
+
+    class SlitAxis(Device):
+        size = Cpt(EpicsMotor, "Size", labels={"motors"})
+        center = Cpt(EpicsMotor, "Center", labels={"motors"})
+
+    # Individual slit directions
+    h = Cpt(SlitAxis, "h")
+    v = Cpt(SlitAxis, "v")
+
+    # Real motors that directly control the slits
+    pitch = FCpt(EpicsMotor, "{_pitch_motor}", labels={"motors"})
+    yaw = FCpt(EpicsMotor, "{_yaw_motor}", labels={"motors"})
+    horizontal = FCpt(EpicsMotor, "{_horizontal_motor}", labels={"motors"})
+    diagonal = FCpt(EpicsMotor, "{_diagonal_motor}", labels={"motors"})

--- a/apstools/devices/jj_transfocators.py
+++ b/apstools/devices/jj_transfocators.py
@@ -1,0 +1,194 @@
+"""
+JJ-Xray Transfocators
+
+Device uses PyDevice for focal size calculation and lens configuration control
+
+    Parameters
+    ==========
+    prefix:
+      EPICS prefix required to communicate with transfocator IOC, ex: "100idPyCRL:CRL:"
+    pitch1_motor:
+      The motor record PV controlling the real pitch motor on CRL1, ex "100id:m4"
+    yaw1_motor:
+      The motor record PV controlling the real yaw motor on CRL1, ex "100id:m5"
+    x1_motor:
+      The motor record PV controlling the real lateral motor on CRL1, ex: "100id:m1"
+    y1_motor:
+      The motor record PV controlling the real vertical motor on CRL1, ex: "100id:m2"
+
+	
+	Optional
+	========
+	For CRL with translation (JJtransfocator1xZ) there's one more motor:
+
+	z1_motor:
+      The motor record PV controlling the real translation motor on CRL1, ex: "100id:m3"
+
+	For two CRL system  (JJtransfocator2x) there's 4 more motors:
+
+    pitch2_motor:
+      The motor record PV controlling the real pitch motor on CRL1, ex "100id:m29"
+    yaw2_motor:
+      The motor record PV controlling the real yaw motor on CRL1, ex "100id:m30"
+    x2_motor:
+      The motor record PV controlling the real lateral motor on CRL1, ex: "100id:m26"
+    y2_motor:
+      The motor record PV controlling the real vertical motor on CRL1, ex: "100id:m27"
+
+	For two CRL system with Translation (JJtransfocator2xZ), there's yet another motor:
+
+	z2_motor:
+      The motor record PV controlling the real translation motor on CRL2, ex: "100id:m28"
+
+"""
+
+
+from ophyd import Component as Cpt
+from ophyd import FormattedComponent as FCpt
+from ophyd import Device
+from ophyd import EpicsSignal, EpicsSignalRO
+from ophyd import EpicsMotor
+from ophyd import PVPositioner
+
+
+class fpower_index(PVPositioner):
+    """
+    focal power index "positioner"; increasing index, increasing focal power
+    """
+    readback = Cpt(EpicsSignalRO, '1:sortedIndex_RBV')
+    setpoint = Cpt(EpicsSignal, '1:sortedInde')
+    done = Cpt(EpicsSignalRO, 'sysBusy')
+
+class focal_size(PVPositioner):
+    """
+    focal size positioner
+    """
+    readback = Cpt(EpicsSignalRO, 'fSize_actual')
+    setpoint = Cpt(EpicsSignal, 'focalSize')
+    done = Cpt(EpicsSignalRO, 'sysBusy')
+
+class JJtransfocator(Device):
+
+    focalPower = FCpt(fpower_index, "{prefix}")
+    focalSize = FCpt(focal_size, "{prefix}")
+
+    q = Cpt(EpicsSignalRO, "q", kind="hinted")
+    dq = Cpt(EpicsSignalRO, "dq", kind="hinted")
+    sam_position_readback = Cpt(EpicsSignalRO, "samplePosition_RBV", kind="hinted")
+    sam_position_offset_readback = Cpt(EpicsSignalRO, "samplePositionOffset_RBV", kind="hinted")
+
+    energy_keV_local = Cpt(EpicsSignal, "EnergyLocal", kind="config")
+    energy_keV_mono = Cpt(EpicsSignalRO, "EnergyBeamline", kind="config")
+    energy_keV_lookup = Cpt(EpicsSignalRO, "energy_rbv", kind="hinted")
+    
+    beamMode = Cpt(EpicsSignal, "beamMode", string=True, kind="config")
+    energyMode = Cpt(EpicsSignal, "energySelect", string=True, kind="config")
+
+    
+class JJtransfocator1x(JJtransfocator):
+    '''
+    Handles single transfocator system
+    
+    '''
+    def __init__(
+        self,
+        prefix: str,
+        pitch1_motor: str,
+        yaw1_motor: str,
+        x1_motor: str,
+        y1_motor: str,
+        *args,
+        **kwargs,
+    ):
+
+        self._pitch1_motor = pitch1_motor
+        self._yaw1_motor = yaw1_motor
+        self._x1_motor = z1_motor
+        self._y1_motor = y1_motor
+        self._z1_motor = z1_motor
+
+        super().__init__(prefix, *args, **kwargs)
+
+    binary_crl1_config = Cpt(EpicsSignalRO, "1:lenses", kind="hinted")
+    bw_crl1_config = Cpt(EpicsSignalRO, "1:lensConfig_BW")
+    rbv_crl1_config = Cpt(EpicsSignalRO, "1:lensConfig_RBV", kind="hinted")
+
+    crl1_z_pos = Cpt(EpicsSignalRO, "1:oePositionOffset_RBV")
+
+    interLensDelay1 = Cpt(EpicsSignal, "1:interLensDelay", kind="config")
+    
+    pitch1 = FCpt(EpicsMotor, "{_pitch1_motor}", labels={"motors"})
+    yaw1 = FCpt(EpicsMotor, "{_yaw1_motor}", labels={"motors"})
+    x1 = FCpt(EpicsMotor, "{_x1_motor}", labels={"motors"})
+    y1 = FCpt(EpicsMotor, "{_y1_motor}", labels={"motors"})
+    
+class JJtransfocator2x(JJtransfocator1x):
+    
+    '''
+    Adds a second transfocator to beamline
+    
+    '''
+    
+    def __init__(
+        self,
+        prefix: str,
+        pitch2_motor: str,
+        yaw2_motor: str,
+        x2_motor: str,
+        y2_motor: str,
+        *args,
+        **kwargs,
+    ):
+
+        self._pitch2_motor = pitch2_motor
+        self._yaw2_motor = yaw2_motor
+        self._x2_motor = z2_motor
+        self._y2_motor = y2_motor
+        self._z2_motor = z2_motor
+
+        super().__init__(prefix, *args, **kwargs)
+    
+    binary_crl2_config = Cpt(EpicsSignalRO, "2:lenses", kind="hinted")
+    bw_crl2_config = Cpt(EpicsSignalRO, "2:lensConfig_BW")
+    rbv_crl2_config = Cpt(EpicsSignalRO, "2:lensConfig_RBV", kind="hinted")
+
+    crl2_z_pos = Cpt(EpicsSignalRO, "2:oePositionOffset_RBV")
+
+    interLensDelay2 = Cpt(EpicsSignal, "2:interLensDelay", kind="config")
+
+    pitch2 = FCpt(EpicsMotor, "{_pitch2_motor}", labels={"motors"})
+    yaw2 = FCpt(EpicsMotor, "{_yaw2_motor}", labels={"motors"})
+    x2 = FCpt(EpicsMotor, "{_x2_motor}", labels={"motors"})
+    y2 = FCpt(EpicsMotor, "{_y2_motor}", labels={"motors"})
+    
+class JJtransfocator1xZ(JJtransfocator1x):
+    
+    def __init__(
+        self,
+        prefix: str,
+        z1_motor: str,
+        *args,
+        **kwargs,
+    ):
+
+        self._z1_motor = z1_motor
+
+        super().__init__(prefix, *args, **kwargs)
+        
+    z1 = FCpt(EpicsMotor, "{_z1_motor}", labels={"motors"})
+
+class JJtransfocator2xZ(JJtransfocator2x):
+    
+    def __init__(
+        self,
+        prefix: str,
+        z2_motor: str,
+        *args,
+        **kwargs,
+    ):
+
+        self._z2_motor = z2_motor
+
+        super().__init__(prefix, *args, **kwargs)
+        
+    z2 = FCpt(EpicsMotor, "{_z2_motor}", labels={"motors"})


### PR DESCRIPTION
Added support for devices using PyDevice module:

1. JJ-Xray Transfocators (both 1- and 2-CRL systems, each CRL containing ~10 lens stacks)
2. AVS Filters (12 filter systems)

Added generalized support for white beam apertures (aka HHL slits) to handle systems not following 25ID nomenclature