### PR TITLE
Skip certain unit tests on GitHub workflows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ describe future plans.
    * Now testing with Python versions 3.9 - Py3.13. (still pinning databroker)
    * Removed 'lifetime' component from 'aps_machine' device.
    * Refactor unit test for change in upstream ophydregistry findall().
+   * Unit testing was taking ~1/2 hour to complete.
    * Update project packaging and installation procedures.
 
 1.7.2

--- a/apstools/devices/tests/test_kohzu_monochromator.py
+++ b/apstools/devices/tests/test_kohzu_monochromator.py
@@ -3,14 +3,15 @@ file: /tmp/kohzu.py
 """
 
 import time
-import pytest
 
+import pytest
 from bluesky import RunEngine
 from bluesky import plan_stubs as bps
 from ophyd import Component
 from ophyd import EpicsMotor
 
-from ...tests import IOC_GP, in_gha_workflow
+from ...tests import IOC_GP
+from ...tests import in_gha_workflow
 from .. import KohzuSeqCtl_Monochromator
 
 

--- a/apstools/devices/tests/test_kohzu_monochromator.py
+++ b/apstools/devices/tests/test_kohzu_monochromator.py
@@ -3,13 +3,14 @@ file: /tmp/kohzu.py
 """
 
 import time
+import pytest
 
 from bluesky import RunEngine
 from bluesky import plan_stubs as bps
 from ophyd import Component
 from ophyd import EpicsMotor
 
-from ...tests import IOC_GP
+from ...tests import IOC_GP, in_gha_workflow
 from .. import KohzuSeqCtl_Monochromator
 
 
@@ -57,6 +58,10 @@ class MyKohzu(KohzuSeqCtl_Monochromator):
         self.m_z.stop()
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 def test_dcm():
     dcm = MyKohzu(IOC_GP, name="dcm")
     assert dcm is not None

--- a/apstools/devices/tests/test_simulated_controllers.py
+++ b/apstools/devices/tests/test_simulated_controllers.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from ...tests import IOC_GP
+from ...tests import IOC_GP, in_gha_workflow
 from ...tests import timed_pause
 from .. import simulated_controllers as sc
 
@@ -15,6 +15,10 @@ PV_SWAIT = f"{IOC_GP}userCalc7"
 PV_TRANS = f"{IOC_GP}userTran7"
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 @pytest.mark.parametrize("sp", [-55, 120, 998])
 @pytest.mark.parametrize(
     "pv, controller_class, context, exp_info",

--- a/apstools/devices/tests/test_simulated_controllers.py
+++ b/apstools/devices/tests/test_simulated_controllers.py
@@ -7,7 +7,8 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from ...tests import IOC_GP, in_gha_workflow
+from ...tests import IOC_GP
+from ...tests import in_gha_workflow
 from ...tests import timed_pause
 from .. import simulated_controllers as sc
 

--- a/apstools/plans/tests/test_alignment.py
+++ b/apstools/plans/tests/test_alignment.py
@@ -21,7 +21,8 @@ from ...callbacks.spec_file_writer import SpecWriterCallback2
 from ...devices import SynPseudoVoigt
 from ...synApps import SwaitRecord
 from ...synApps import setup_lorentzian_swait
-from ...tests import IOC_GP, in_gha_workflow
+from ...tests import IOC_GP
+from ...tests import in_gha_workflow
 from .. import alignment
 from ._scaler import ScalerCH
 
@@ -399,6 +400,10 @@ parms_no_signal__ZeroDivisionError = _TestParameters(0, 0, 0, 0.1, 0.2, -0.7, 0.
 parms_bkg_only__ZeroDivisionError = _TestParameters(0, 1, 0, 0.1, 0.2, -0.7, 0.5, 11, 1, 0.005, None)
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 @pytest.mark.parametrize(
     "parms",
     [

--- a/apstools/plans/tests/test_alignment.py
+++ b/apstools/plans/tests/test_alignment.py
@@ -155,6 +155,10 @@ parms_max = _TestParameters(pvoigt, axis, -1.2, 1.2, 11, "max", False)
 parms_min___pathological = _TestParameters(pvoigt, axis, -1.2, 1.2, 11, "min", False)
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Deprecated code. Slow to run.  Don't bother testing in GHA.",
+)
 @pytest.mark.parametrize(
     "parms",
     [

--- a/apstools/plans/tests/test_alignment.py
+++ b/apstools/plans/tests/test_alignment.py
@@ -21,7 +21,7 @@ from ...callbacks.spec_file_writer import SpecWriterCallback2
 from ...devices import SynPseudoVoigt
 from ...synApps import SwaitRecord
 from ...synApps import setup_lorentzian_swait
-from ...tests import IOC_GP
+from ...tests import IOC_GP, in_gha_workflow
 from .. import alignment
 from ._scaler import ScalerCH
 
@@ -220,6 +220,10 @@ parms_max = _TestParameters(pvoigt, axis, -1.2, 1.2, 11, "max", 1)
 parms_min___pathological = _TestParameters(pvoigt, axis, -1.2, 1.2, 11, "min", 1)
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 @pytest.mark.parametrize(
     "parms",
     [
@@ -257,6 +261,10 @@ def test_lineup2(parms: _TestParameters):
     )
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 @pytest.mark.parametrize("detectors", [[noisy], [I0], [scaler1], [I0, scaler1]])
 def test_lineup2_issue_1049(detectors):
     scaler1.select_channels(["I0"])

--- a/apstools/plans/tests/test_sscan_support.py
+++ b/apstools/plans/tests/test_sscan_support.py
@@ -4,14 +4,19 @@ from bluesky import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
 from ophyd import EpicsMotor
 from ophyd.scaler import ScalerCH
+import pytest
 
 from ...synApps import SscanDevice
-from ...tests import IOC_GP
+from ...tests import IOC_GP, in_gha_workflow
 
 from ..sscan_support import _get_sscan_data_objects
 from ..sscan_support import sscan_1D
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 def test_i108():
     cat = databroker.temp().v2
     RE = RunEngine({})

--- a/apstools/plans/tests/test_sscan_support.py
+++ b/apstools/plans/tests/test_sscan_support.py
@@ -1,14 +1,14 @@
 import databroker
+import pytest
 from bluesky import RunEngine
 from bluesky import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
 from ophyd import EpicsMotor
 from ophyd.scaler import ScalerCH
-import pytest
 
 from ...synApps import SscanDevice
-from ...tests import IOC_GP, in_gha_workflow
-
+from ...tests import IOC_GP
+from ...tests import in_gha_workflow
 from ..sscan_support import _get_sscan_data_objects
 from ..sscan_support import sscan_1D
 

--- a/apstools/synApps/tests/test_acalcout.py
+++ b/apstools/synApps/tests/test_acalcout.py
@@ -14,12 +14,25 @@ from .. import UserArrayCalcDevice
 TEST_PV = f"{IOC_GP}userArrayCalc10"
 
 
+def in_gha_workflow():
+    """Return True if running in a workflow on GitHub Actions."""
+    import os
+
+    return "/home/runner/" in os.environ.get("MAMBA_EXE", "")
+
+
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 def test_connected():
     acalcout = AcalcoutRecord(TEST_PV, name="acalcout")
-    timed_pause(0.25)
-    if not acalcout.connected:
-        for nm in acalcout.component_names:
-            assert getattr(acalcout, nm).connected, f"{nm}"
+    try:
+        acalcout.wait_for_connection(timeout=1)
+    except TimeoutError:
+        if not acalcout.connected:
+            for nm in acalcout.component_names:
+                assert getattr(acalcout, nm).connected, f"{nm}"
 
 
 @pytest.mark.parametrize(

--- a/apstools/synApps/tests/test_acalcout.py
+++ b/apstools/synApps/tests/test_acalcout.py
@@ -6,7 +6,8 @@ import time
 import pytest
 
 from ...tests import IOC_GP
-from ...tests import common_attribute_quantities_test, in_gha_workflow
+from ...tests import common_attribute_quantities_test
+from ...tests import in_gha_workflow
 from ...tests import timed_pause
 from .. import AcalcoutRecord
 from .. import UserArrayCalcDevice

--- a/apstools/synApps/tests/test_acalcout.py
+++ b/apstools/synApps/tests/test_acalcout.py
@@ -6,19 +6,12 @@ import time
 import pytest
 
 from ...tests import IOC_GP
-from ...tests import common_attribute_quantities_test
+from ...tests import common_attribute_quantities_test, in_gha_workflow
 from ...tests import timed_pause
 from .. import AcalcoutRecord
 from .. import UserArrayCalcDevice
 
 TEST_PV = f"{IOC_GP}userArrayCalc10"
-
-
-def in_gha_workflow():
-    """Return True if running in a workflow on GitHub Actions."""
-    import os
-
-    return "/home/runner/" in os.environ.get("MAMBA_EXE", "")
 
 
 @pytest.mark.skipif(

--- a/apstools/synApps/tests/test_sseq.py
+++ b/apstools/synApps/tests/test_sseq.py
@@ -3,12 +3,17 @@ from ophyd import EpicsSignal
 
 from ...tests import IOC_GP
 from ...tests import common_attribute_quantities_test
+from ...tests import in_gha_workflow
 from ...tests import timed_pause
 from ..sseq import SseqRecord
 from ..sseq import UserStringSequenceDevice
 from ..sseq import sseqRecordStep
 
 
+@pytest.mark.skipif(
+    in_gha_workflow(),
+    reason="Random failures in GiHub Actions workflows.",
+)
 @pytest.mark.parametrize(
     "device, pv, connect, attr, expected",
     [

--- a/apstools/tests/__init__.py
+++ b/apstools/tests/__init__.py
@@ -92,6 +92,15 @@ def common_attribute_quantities_test(device, pv, connect, attr, expected):
         l = len(getattr(obj, attr))
     assert l == expected, f"{attr}: {l} != {expected}"
 
+def in_gha_workflow():
+    """Return True if running in a workflow on GitHub Actions."""
+    import os
+
+    # https://stackoverflow.com/a/73973555/1046449
+    keys = "GITHUB_ACTIONS TRAVIS CIRCLECI GITLAB_CI".split()
+    indicators = [os.getenv(key) for key in keys]
+    return "true" in indicators
+
 
 def rand(base, scale):
     return base + scale * random.random()

--- a/apstools/tests/__init__.py
+++ b/apstools/tests/__init__.py
@@ -92,6 +92,7 @@ def common_attribute_quantities_test(device, pv, connect, attr, expected):
         l = len(getattr(obj, attr))
     assert l == expected, f"{attr}: {l} != {expected}"
 
+
 def in_gha_workflow():
     """Return True if running in a workflow on GitHub Actions."""
     import os

--- a/apstools/utils/tests/test_statistics.py
+++ b/apstools/utils/tests/test_statistics.py
@@ -77,7 +77,7 @@ def test_xy_statistics(data):
         if isinstance(received, str):
             assert f"{received}" == expected, f"{key=} {expected=} {stats=} {data['file']=!r}"
         elif isinstance(received, float):
-            assert math.isclose(received, expected, abs_tol=1e-6)
+            assert math.isclose(received, float(expected), abs_tol=1e-6), f"{key=} {received=} {expected=}"
 
 
 @pytest.mark.parametrize(

--- a/apstools/utils/tests/test_statistics.py
+++ b/apstools/utils/tests/test_statistics.py
@@ -1,5 +1,6 @@
 """Test the utils.statistics module."""
 
+import math
 import pathlib
 from contextlib import nullcontext as does_not_raise
 
@@ -73,7 +74,10 @@ def test_xy_statistics(data):
     unknown = object()
     for key, expected in data["advice"].items():
         received = stats.get(key, unknown)
-        assert f"{received}" == expected, f"{key=} {expected=} {stats=} {data['file']=!r}"
+        if isinstance(received, str):
+            assert f"{received}" == expected, f"{key=} {expected=} {stats=} {data['file']=!r}"
+        elif isinstance(received, float):
+            assert math.isclose(received, expected, abs_tol=1e-6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- close #1071

Doing this work in two parts.  It's most important to skip the unit tests that fail randomly in GH workflows (probably fail due to EPICS IOC response in the workflow).  PV timeouts & unchanged values are the principal failure modes.

1. Mark failing (or slow) tests with `@pytest.mark.skipif(in_gha_workflow())` decorator (this branch)
2. Refactor or replace marked tests with more efficient tests. (#1077)