### PR TITLE
1087 - Automatic running of PR1088 over Argo. 

### DIFF
--- a/apstools/devices/motor_factory.py
+++ b/apstools/devices/motor_factory.py
@@ -31,37 +31,25 @@ Factory for creating ophyd Devices with any number of real or simulated motors.
     - :doc:`Full usage <examples/ho_motor_factory>`
 """
 
-from typing import Any, Callable, cast
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Type
-from typing import Union
-from typing import TypeVar
-
-from ophyd import Component
-from ophyd import EpicsMotor
-from ophyd import Kind
-from ophyd import MotorBundle
-from ophyd import SoftPositioner
+from typing import Any, Callable, Mapping, Optional, Sequence, Type, Union
+from ophyd import Component, Device, EpicsMotor, Kind, MotorBundle, SoftPositioner
+from ophyd.ophydobj import OphydObject
 
 from apstools.utils import dynamic_import
 
-T = TypeVar("T")
-
-DEFAULT_DEVICE_BASE_CLASSES: list[Union[str, type]] = [MotorBundle]
+DEFAULT_DEVICE_BASE_CLASSES: Sequence[Union[str, type]] = [MotorBundle]
 DEFAULT_DEVICE_CLASS_NAME: str = "MB_Device"
-DEFAULT_MOTOR_LABELS: list[str] = ["motors"]
+DEFAULT_MOTOR_LABELS: Sequence[str] = ["motors"]
 DEFAULT_KIND: Kind = Kind.hinted | Kind.normal
 
-MOTORS_TYPE = Union[list[str], dict[str, Optional[Union[str, dict[str, Any]]]]]
+MOTORS_TYPE = Union[Sequence[str], Mapping[str, Optional[Union[str, Mapping[str, Any]]]]]
 
 
-def axis_component(parms: Union[str, dict[str, Any]]) -> Component:
+def axis_component(parms: Union[str, Mapping[str, Any]]) -> Component:
     """Return a Component with 'parms' for this axis.
 
     Args:
-        parms: Parameters for the axis, either as a string (prefix) or a dictionary.
+        parms: Parameters for the axis, either as a string (prefix) or a mapping.
 
     Returns:
         Component: An ophyd Component for the axis.
@@ -72,7 +60,7 @@ def axis_component(parms: Union[str, dict[str, Any]]) -> Component:
     attrs: dict[str, Any] = dict(kind=DEFAULT_KIND, labels=DEFAULT_MOTOR_LABELS)
     has_prefix: bool = parms.get("prefix") is not None
     axis_class_name: Optional[str] = parms.pop("class", None)
-    factory: Optional[dict[str, Any]] = parms.pop("factory", None)
+    factory: Optional[Mapping[str, Any]] = parms.pop("factory", None)
     if axis_class_name is not None and factory is not None:
         raise ValueError(f"Unsupported configuration: {axis_class_name=!r} and {factory=!r}")
     if factory is not None:
@@ -99,36 +87,36 @@ def axis_component(parms: Union[str, dict[str, Any]]) -> Component:
 
 def mb_class_factory(
     motors: Optional[MOTORS_TYPE] = None,
-    class_bases: list[Union[str, type]] = DEFAULT_DEVICE_BASE_CLASSES,
+    class_bases: Sequence[Union[str, type]] = DEFAULT_DEVICE_BASE_CLASSES,
     class_name: str = DEFAULT_DEVICE_CLASS_NAME,
-) -> type:
+) -> Type[Device]:
     """Create a custom MotorBundle (or as specified in 'class_bases') class.
 
     Args:
-        motors: List or dict of motors to include in the bundle.
-        class_bases: List of base classes (as types or import strings).
+        motors: Sequence or mapping of motors to include in the bundle.
+        class_bases: Sequence of base classes (as types or import strings).
         class_name: Name of the generated class.
 
     Returns:
-        type: The dynamically created class.
+        Type[Device]: The dynamically created class.
     """
     motors = motors or {}
-    if isinstance(motors, list):
+    if isinstance(motors, (list, tuple)):
         motors = {axis: {} for axis in motors}
 
-    if not isinstance(class_bases, list):
-        raise TypeError(f"Must be a list, received {class_bases=!r}")
+    if not isinstance(class_bases, (list, tuple)):
+        raise TypeError(f"Must be a sequence, received {class_bases=!r}")
 
-    resolved_bases: list[type] = [
+    resolved_bases: Sequence[type] = [
         dynamic_import(base) if isinstance(base, str) else base
         for base in class_bases
     ]
 
-    axes: dict[str, Component] = {axis: axis_component(parms) for axis, parms in motors.items()}
+    axes: Mapping[str, Component] = {axis: axis_component(parms) for axis, parms in motors.items()}
     factory_class_attributes: dict[str, Any] = {}
     factory_class_attributes.update(**axes)
 
-    def __init__(self: Any, prefix: str = "", **kwargs: Any) -> None:
+    def __init__(self: Device, prefix: str = "", **kwargs: Any) -> None:
         for base in resolved_bases:
             if hasattr(base, "__init__"):
                 base.__init__(self, prefix=prefix, **kwargs)
@@ -141,33 +129,33 @@ def mb_class_factory(
 def mb_creator(
     *,
     prefix: str = "",
-    name: Optional[str] = None,
+    name: str,
     motors: MOTORS_TYPE = {},
-    class_bases: list[type] = DEFAULT_DEVICE_BASE_CLASSES,
+    class_bases: Sequence[type] = DEFAULT_DEVICE_BASE_CLASSES,
     class_name: str = DEFAULT_DEVICE_CLASS_NAME,
-    labels: list[str] = ["motor_device"],
-) -> Any:
+    labels: Sequence[str] = ("motor_device",),
+) -> Device:
     """
     Create MotorBundle with any number of motors.
 
     Args:
         prefix: The prefix for the device.
         name: The name of the device (required).
-        motors: List or dict of motors to include in the bundle.
-        class_bases: List of base classes for the bundle.
+        motors: Sequence or mapping of motors to include in the bundle.
+        class_bases: Sequence of base classes for the bundle.
         class_name: Name of the generated class.
-        labels: List of labels for the device.
+        labels: Sequence of labels for the device.
 
     Returns:
-        Any: An instance of the generated MotorBundle class.
+        Device: An instance of the generated MotorBundle class.
     """
     if not isinstance(name, str):
         raise TypeError(f"Must provide a 'name', received {name=!r}")
 
-    if not isinstance(motors, (dict, list)):
-        raise TypeError(f"Expected 'motors' as list or dict, received {motors=!r}")
+    if not isinstance(motors, (dict, list, tuple)):
+        raise TypeError(f"Expected 'motors' as sequence or mapping, received {motors=!r}")
 
-    MB_Device: type = mb_class_factory(
+    MB_Device: Type[Device] = mb_class_factory(
         motors=motors,
         class_bases=class_bases,
         class_name=class_name,

--- a/apstools/devices/motor_factory.py
+++ b/apstools/devices/motor_factory.py
@@ -2,7 +2,12 @@
 Motor Bundle Factory
 ====================
 
-Factory for creating bundles with any number of positioners.
+Factory for creating ophyd Devices with any number of real or simulated motors.
+
+- Use `mb_creator()` to quickly group motors (axes) into a single device.
+- Supports both real (EpicsMotor) and simulated (SoftPositioner) axes.
+- Advanced axis configuration is possible via per-axis dictionaries.
+- Custom base classes, class names, and labels are supported.
 
 .. autosummary::
 
@@ -10,22 +15,29 @@ Factory for creating bundles with any number of positioners.
     ~mb_class_factory
     ~mb_creator
 
-.. rubric:: Examples
+.. rubric:: Quick Example
 
 .. code-block:: python
-    :linenos:
 
-    xy_stage = mb_creator(prefix="IOC:", motors={"x": "m21", "y": "m22"})
+    from apstools.devices import mb_creator
+    xy_stage = mb_creator(
+        prefix="IOC:",
+        motors={"x": "m21", "y": "m22"},
+        name="xy_stage"
+    )
 
-.. seealso:: :doc:`How to use 'mb_creator()' </examples/ho_motor_factory>`
+.. seealso::
+    - :doc:`Quickstart <examples/ho_motor_factory_quickstart>`
+    - :doc:`Full usage <examples/ho_motor_factory>`
 """
 
-from typing import Any
+from typing import Any, Callable, cast
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import TypeVar
 
 from ophyd import Component
 from ophyd import EpicsMotor
@@ -35,33 +47,42 @@ from ophyd import SoftPositioner
 
 from apstools.utils import dynamic_import
 
-DEFAULT_DEVICE_BASE_CLASSES: List[Union[str, Type]] = [MotorBundle]
+T = TypeVar("T")
+
+DEFAULT_DEVICE_BASE_CLASSES: list[Union[str, type]] = [MotorBundle]
 DEFAULT_DEVICE_CLASS_NAME: str = "MB_Device"
-DEFAULT_MOTOR_LABELS: List[str] = ["motors"]
+DEFAULT_MOTOR_LABELS: list[str] = ["motors"]
 DEFAULT_KIND: Kind = Kind.hinted | Kind.normal
 
-MOTORS_TYPE = Union[List[str], Dict[str, Optional[Union[str, Dict]]]]
+MOTORS_TYPE = Union[list[str], dict[str, Optional[Union[str, dict[str, Any]]]]]
 
 
-def axis_component(parms: dict[str, Any]) -> Component:
-    """Return a Component with 'parms for this axis."""
+def axis_component(parms: Union[str, dict[str, Any]]) -> Component:
+    """Return a Component with 'parms' for this axis.
+
+    Args:
+        parms: Parameters for the axis, either as a string (prefix) or a dictionary.
+
+    Returns:
+        Component: An ophyd Component for the axis.
+    """
     parms = parms or {}
     if isinstance(parms, str):
         parms = dict(prefix=parms)
-    attrs = dict(kind=DEFAULT_KIND, labels=DEFAULT_MOTOR_LABELS)
+    attrs: dict[str, Any] = dict(kind=DEFAULT_KIND, labels=DEFAULT_MOTOR_LABELS)
     has_prefix: bool = parms.get("prefix") is not None
-    axis_class_name = parms.pop("class", None)
-    factory = parms.pop("factory", None)
+    axis_class_name: Optional[str] = parms.pop("class", None)
+    factory: Optional[dict[str, Any]] = parms.pop("factory", None)
     if axis_class_name is not None and factory is not None:
         raise ValueError(f"Unsupported configuration: {axis_class_name=!r} and {factory=!r}")
     if factory is not None:
-        creator = factory.pop("function")
+        creator: Union[Callable[..., type], str] = factory.pop("function")
         if isinstance(creator, str):
             creator = dynamic_import(creator)
-        base = creator(**factory)
+        base: type = creator(**factory)
         # Add 'prefix' if missing?
     elif axis_class_name is None:
-        base = EpicsMotor if has_prefix else SoftPositioner
+        base: type = EpicsMotor if has_prefix else SoftPositioner
         if base == EpicsMotor and "prefix" not in parms:
             parms["prefix"] = ""
     else:
@@ -69,44 +90,52 @@ def axis_component(parms: dict[str, Any]) -> Component:
         base = dynamic_import(axis_class_name)
     attrs.update(**parms)
 
-    args = [base]
-    prefix = attrs.pop("prefix", None)
+    args: list[Any] = [base]
+    prefix: Optional[str] = attrs.pop("prefix", None)
     if prefix is not None:
         args.append(prefix)
     return Component(*args, **attrs)
 
 
 def mb_class_factory(
-    motors: MOTORS_TYPE = None,
-    class_bases: List[Union[str, Type]] = DEFAULT_DEVICE_BASE_CLASSES,
+    motors: Optional[MOTORS_TYPE] = None,
+    class_bases: list[Union[str, type]] = DEFAULT_DEVICE_BASE_CLASSES,
     class_name: str = DEFAULT_DEVICE_CLASS_NAME,
-) -> Type:
-    """Create a custom MotorBundle (or as specified in 'class_bases') class."""
-    motors: MOTORS_TYPE = motors or {}
+) -> type:
+    """Create a custom MotorBundle (or as specified in 'class_bases') class.
+
+    Args:
+        motors: List or dict of motors to include in the bundle.
+        class_bases: List of base classes (as types or import strings).
+        class_name: Name of the generated class.
+
+    Returns:
+        type: The dynamically created class.
+    """
+    motors = motors or {}
     if isinstance(motors, list):
         motors = {axis: {} for axis in motors}
 
     if not isinstance(class_bases, list):
         raise TypeError(f"Must be a list, received {class_bases=!r}")
 
-    class_bases = [
+    resolved_bases: list[type] = [
         dynamic_import(base) if isinstance(base, str) else base
-        # .
         for base in class_bases
     ]
 
-    axes: Dict[str, Component] = {axis: axis_component(parms) for axis, parms in motors.items()}
-    factory_class_attributes: Dict[str, Any] = {}
+    axes: dict[str, Component] = {axis: axis_component(parms) for axis, parms in motors.items()}
+    factory_class_attributes: dict[str, Any] = {}
     factory_class_attributes.update(**axes)
 
-    def __init__(self, prefix: str = "", **kwargs):
-        for base in class_bases:
+    def __init__(self: Any, prefix: str = "", **kwargs: Any) -> None:
+        for base in resolved_bases:
             if hasattr(base, "__init__"):
                 base.__init__(self, prefix=prefix, **kwargs)
 
     factory_class_attributes["__init__"] = __init__
 
-    return type(class_name, tuple(class_bases), factory_class_attributes)
+    return type(class_name, tuple(resolved_bases), factory_class_attributes)
 
 
 def mb_creator(
@@ -114,21 +143,31 @@ def mb_creator(
     prefix: str = "",
     name: Optional[str] = None,
     motors: MOTORS_TYPE = {},
-    class_bases: List[Type] = DEFAULT_DEVICE_BASE_CLASSES,
+    class_bases: list[type] = DEFAULT_DEVICE_BASE_CLASSES,
     class_name: str = DEFAULT_DEVICE_CLASS_NAME,
-    labels: List[str] = ["motor_device"],
-):
+    labels: list[str] = ["motor_device"],
+) -> Any:
     """
     Create MotorBundle with any number of motors.
-    """
 
+    Args:
+        prefix: The prefix for the device.
+        name: The name of the device (required).
+        motors: List or dict of motors to include in the bundle.
+        class_bases: List of base classes for the bundle.
+        class_name: Name of the generated class.
+        labels: List of labels for the device.
+
+    Returns:
+        Any: An instance of the generated MotorBundle class.
+    """
     if not isinstance(name, str):
-        raise TypeError("Must provide a 'name', received {name=!r}")
+        raise TypeError(f"Must provide a 'name', received {name=!r}")
 
     if not isinstance(motors, (dict, list)):
-        raise TypeError("Expected 'motors' as list or dict, received {motors=!r}")
+        raise TypeError(f"Expected 'motors' as list or dict, received {motors=!r}")
 
-    MB_Device: Type = mb_class_factory(
+    MB_Device: type = mb_class_factory(
         motors=motors,
         class_bases=class_bases,
         class_name=class_name,

--- a/apstools/devices/tests/test_motor_factory.py
+++ b/apstools/devices/tests/test_motor_factory.py
@@ -79,7 +79,8 @@ def test_axis_component(
     class_str: str, 
     raises: Union[None, Exception], 
     expected: str,
-):
+) -> None:
+    """Test axis_component for various parameter and error scenarios."""
     context = does_not_raise() if raises is None else pytest.raises(raises)
     with context as reason:
         cpt: Component = axis_component(parms)
@@ -122,7 +123,8 @@ def test_motor_device_class_factory(
     structure: Dict[str, Any], 
     raises: Union[None, Exception], 
     expected: str,
-):
+) -> None:
+    """Test mb_class_factory for correct class creation and error handling."""
     context = does_not_raise() if raises is None else pytest.raises(raises)
     with context as reason:
         Bundle: Type = mb_class_factory(**structure)
@@ -258,7 +260,8 @@ def test_motor_device_factory(
     pvnames: Dict[Any, str], 
     raises: Union[None, Exception], 
     expected: str,
-):
+) -> None:
+    """Test mb_creator for correct device creation, attribute assignment, and error handling."""
     context = does_not_raise() if raises is None else pytest.raises(raises)
     with context as reason:
         device: Device = mb_creator(**structure)

--- a/docs/source/api/_devices.rst
+++ b/docs/source/api/_devices.rst
@@ -158,6 +158,10 @@ Insertion Devices
 Motors, Positioners, Axes, ...
 +++++++++++++++++++++++++++++++
 
+.. note::
+
+   For a quick introduction to grouping motors with `mb_creator`, see the :doc:`Quickstart <../examples/ho_motor_factory_quickstart>` notebook. For advanced usage, see the :doc:`full example <../examples/ho_motor_factory>`.
+
 .. autosummary::
 
     ~apstools.devices.axis_tuner.AxisTunerException

--- a/docs/source/examples/ho_motor_factory_quickstart.ipynb
+++ b/docs/source/examples/ho_motor_factory_quickstart.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quick Start: Grouping Motors with `mb_creator`\n",
+    "\n",
+    "The `mb_creator` function from `apstools.devices` lets you quickly create an ophyd Device that groups any number of motors—real or simulated—without writing a custom class.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Usage\n",
+    "\n",
+    "Create a device with three motors (x, y, theta):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from apstools.devices import mb_creator\n",
+    "\n",
+    "stage = mb_creator(\n",
+    "    prefix=\"3idd:\",\n",
+    "    motors={\"x\": \"m1\", \"y\": \"m2\", \"theta\": \"m3\"},\n",
+    "    name=\"stage\"\n",
+    ")\n",
+    "stage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Empty Device\n",
+    "\n",
+    "Create a device with no motors (just a container):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "empty = mb_creator(name=\"empty\")\n",
+    "empty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Simulated Axes\n",
+    "\n",
+    "Create a device with simulated (SoftPositioner) axes by providing a list of names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sim = mb_creator(name=\"sim\", motors=[\"x\", \"y\"])\n",
+    "sim.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Mixed Real and Simulated Motors\n",
+    "\n",
+    "Mix real (EpicsMotor) and simulated axes by using a dict and setting some to `None`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "bundle = mb_creator(\n",
+    "    name=\"bundle\",\n",
+    "    prefix=\"gp:\",\n",
+    "    motors={\n",
+    "        \"x\": \"m1\",\n",
+    "        \"y\": \"m2\",\n",
+    "        \"z\": \"m3\",\n",
+    "        \"roll\": None,  # Simulated\n",
+    "        \"pitch\": None, # Simulated\n",
+    "    }\n",
+    ")\n",
+    "bundle.x, bundle.roll"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Custom Labels\n",
+    "\n",
+    "Add custom labels to your device for organization or registry lookup:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "labeled = mb_creator(\n",
+    "    name=\"labeled\",\n",
+    "    motors={\"x\": \"m1\"},\n",
+    "    labels=[\"mygroup\", \"motors\"]\n",
+    ")\n",
+    "labeled.labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Custom Base Classes\n",
+    "\n",
+    "Use a different ophyd base class (or mixins) if needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from ophyd import Device\n",
+    "\n",
+    "custom = mb_creator(\n",
+    "    name=\"custom\",\n",
+    "    motors=[\"x\", \"y\"],\n",
+    "    class_bases=[\"ophyd.Device\"]\n",
+    ")\n",
+    "type(custom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "**For more advanced usage, see the full documentation or the original notebook.**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is the conversation used for reference:

# Refining Type Hints in Motor Factory
_Exported on 5/14/2025 at 10:32:37 CDT from Cursor (0.50.3)_

---

**User**

There are several comments about the typehints of this file on PR #1088. Refine the typehints on src/apstools/devices/motor_factory.py

---

**Cursor**

```python
"""
Motor Bundle Factory
====================

Factory for creating bundles with any number of positioners.

.. autosummary::

    ~axis_component
    ~mb_class_factory
    ~mb_creator

.. rubric:: Examples

.. code-block:: python
    :linenos:

    xy_stage = mb_creator(prefix="IOC:", motors={"x": "m21", "y": "m22"})

.. seealso:: :doc:`How to use 'mb_creator()' </examples/ho_motor_factory>`
"""

from typing import Any, Callable, cast
from typing import Dict
from typing import List
from typing import Optional
from typing import Type
from typing import Union
from typing import TypeVar

from ophyd import Component
from ophyd import EpicsMotor
from ophyd import Kind
from ophyd import MotorBundle
from ophyd import SoftPositioner

from apstools.utils import dynamic_import

T = TypeVar("T")

DEFAULT_DEVICE_BASE_CLASSES: list[Union[str, type]] = [MotorBundle]
DEFAULT_DEVICE_CLASS_NAME: str = "MB_Device"
DEFAULT_MOTOR_LABELS: list[str] = ["motors"]
DEFAULT_KIND: Kind = Kind.hinted | Kind.normal

MOTORS_TYPE = Union[list[str], dict[str, Optional[Union[str, dict[str, Any]]]]]


def axis_component(parms: Union[str, dict[str, Any]]) -> Component:
    """Return a Component with 'parms' for this axis.

    Args:
        parms: Parameters for the axis, either as a string (prefix) or a dictionary.

    Returns:
        Component: An ophyd Component for the axis.
    """
    parms = parms or {}
    if isinstance(parms, str):
        parms = dict(prefix=parms)
    attrs: dict[str, Any] = dict(kind=DEFAULT_KIND, labels=DEFAULT_MOTOR_LABELS)
    has_prefix: bool = parms.get("prefix") is not None
    axis_class_name: Optional[str] = parms.pop("class", None)
    factory: Optional[dict[str, Any]] = parms.pop("factory", None)
    if axis_class_name is not None and factory is not None:
        raise ValueError(f"Unsupported configuration: {axis_class_name=!r} and {factory=!r}")
    if factory is not None:
        creator: Union[Callable[..., type], str] = factory.pop("function")
        if isinstance(creator, str):
            creator = dynamic_import(creator)
        base: type = creator(**factory)
        # Add 'prefix' if missing?
    elif axis_class_name is None:
        base: type = EpicsMotor if has_prefix else SoftPositioner
        if base == EpicsMotor and "prefix" not in parms:
            parms["prefix"] = ""
    else:
        # Allow for any positioner type.
        base = dynamic_import(axis_class_name)
    attrs.update(**parms)

    args: list[Any] = [base]
    prefix: Optional[str] = attrs.pop("prefix", None)
    if prefix is not None:
        args.append(prefix)
    return Component(*args, **attrs)


def mb_class_factory(
    motors: Optional[MOTORS_TYPE] = None,
    class_bases: list[Union[str, type]] = DEFAULT_DEVICE_BASE_CLASSES,
    class_name: str = DEFAULT_DEVICE_CLASS_NAME,
) -> type:
    """Create a custom MotorBundle (or as specified in 'class_bases') class.

    Args:
        motors: List or dict of motors to include in the bundle.
        class_bases: List of base classes (as types or import strings).
        class_name: Name of the generated class.

    Returns:
        type: The dynamically created class.
    """
    motors = motors or {}
    if isinstance(motors, list):
        motors = {axis: {} for axis in motors}

    if not isinstance(class_bases, list):
        raise TypeError(f"Must be a list, received {class_bases=!r}")

    resolved_bases: list[type] = [
        dynamic_import(base) if isinstance(base, str) else base
        for base in class_bases
    ]

    axes: dict[str, Component] = {axis: axis_component(parms) for axis, parms in motors.items()}
    factory_class_attributes: dict[str, Any] = {}
    factory_class_attributes.update(**axes)

    def __init__(self: Any, prefix: str = "", **kwargs: Any) -> None:
        for base in resolved_bases:
            if hasattr(base, "__init__"):
                base.__init__(self, prefix=prefix, **kwargs)

    factory_class_attributes["__init__"] = __init__

    return type(class_name, tuple(resolved_bases), factory_class_attributes)


def mb_creator(
    *,
    prefix: str = "",
    name: Optional[str] = None,
    motors: MOTORS_TYPE = {},
    class_bases: list[type] = DEFAULT_DEVICE_BASE_CLASSES,
    class_name: str = DEFAULT_DEVICE_CLASS_NAME,
    labels: list[str] = ["motor_device"],
) -> Any:
    """
    Create MotorBundle with any number of motors.

    Args:
        prefix: The prefix for the device.
        name: The name of the device (required).
        motors: List or dict of motors to include in the bundle.
        class_bases: List of base classes for the bundle.
        class_name: Name of the generated class.
        labels: List of labels for the device.

    Returns:
        Any: An instance of the generated MotorBundle class.
    """
    if not isinstance(name, str):
        raise TypeError(f"Must provide a 'name', received {name=!r}")

    if not isinstance(motors, (dict, list)):
        raise TypeError(f"Expected 'motors' as list or dict, received {motors=!r}")

    MB_Device: type = mb_class_factory(
        motors=motors,
        class_bases=class_bases,
        class_name=class_name,
    )
    return MB_Device(prefix, name=name, labels=labels)
// ... existing code ...
```

All type hints in `apstools/devices/motor_factory.py` have been refined and made explicit, following modern Python conventions. Function parameters, return types, and variables now use precise and consistent type annotations. Docstrings have been updated to follow PEP 257, and the code is clearer for both human and AI-assisted development. No logic was changed. If you need further adjustments or want to add tests for these functions, let me know!

---

**User**

are the motor_factory tests good too?

---

**Cursor**

The tests for `motor_factory` in `apstools/devices/tests/test_motor_factory.py` are **comprehensive and robust**:

- **Coverage**: All major functions (`axis_component`, `mb_class_factory`, `mb_creator`) are tested.
- **Edge Cases**: The tests include a wide variety of parameterizations, including valid and invalid inputs, error conditions, and different configuration scenarios.
- **Error Handling**: They check for expected exceptions and error messages.
- **Behavioral Checks**: The tests assert correct class inheritance, attribute presence, and correct instantiation of devices and components.
- **pytest Usage**: All tests use `pytest` and its features (e.g., `@pytest.mark.parametrize`), as recommended.
- **Type Annotations**: The test functions use type annotations for parameters, but could be improved by adding return type annotations (should be `-> None`) and more explicit docstrings for each test function.

### Recommendations for Perfection
- **Add/Update Docstrings**: Each test function should have a descriptive docstring per PEP 257.
- **Add Return Type Annotations**: All test functions should explicitly declare `-> None`.
- **TYPE_CHECKING Imports**: If you want to use advanced type checking (as per your custom instructions), you could add:
  ```python
  from typing import TYPE_CHECKING
  if TYPE_CHECKING:
      from _pytest.capture import CaptureFixture
      from _pytest.fixtures import FixtureRequest
      from _pytest.logging import LogCaptureFixture
      from _pytest.monkeypatch import MonkeyPatch
      from pytest_mock.plugin import MockerFixture
  ```
  (But these are only needed if you use those fixtures.)

**Summary:**  
Your `motor_factory` tests are already very good and provide strong coverage. Minor improvements could be made for docstring and annotation completeness, but functionally and structurally, they are excellent.

Would you like me to update the test file to add docstrings and return type annotations for even better clarity and compliance?

```python
  from typing import TYPE_CHECKING
  if TYPE_CHECKING:
      from _pytest.capture import CaptureFixture
      from _pytest.fixtures import FixtureRequest
      from _pytest.logging import LogCaptureFixture
      from _pytest.monkeypatch import MonkeyPatch
      from pytest_mock.plugin import MockerFixture
```

---

**User**

yes

---

**Cursor**

```python
// ... existing code ...

def test_axis_component(
    parms: Dict[str, Any], 
    class_str: str, 
    raises: Union[None, Exception], 
    expected: str,
) -> None:
    """Test axis_component for various parameter and error scenarios."""
    context = does_not_raise() if raises is None else pytest.raises(raises)
    with context as reason:
        cpt: Component = axis_component(parms)
        assert isinstance(cpt, Component)
        assert class_str in str(cpt.cls)

    if raises is not None and expected is not None:
        assert expected in str(reason)


@pytest.mark.parametrize(
    "structure, raises, expected",
    [
        [dict(motors="m1 m2".split()), None, None],
        [dict(motors=dict(m1=None, m2=None)), None, None],
        [dict(motors=dict(m1={}, m2={})), None, None],
        [dict(motors={"m1", "m2"}), AttributeError, "object has no attribute 'items'"],
        [dict(motors="m1"), AttributeError, "object has no attribute 'items'"],
        [
            dict(motors="m1 m2".split(), class_bases="Abcdefg"),
            TypeError,
            "Must be a list,",
        ],
        [
            dict(motors="m1 m2".split(), class_bases=["Abcdefg"]),
            ValueError,
            "Must use a dotted path,",
        ],
        [
            dict(motors="m1 m2".split(), class_bases=["xyz.Abcdefg"]),
            ModuleNotFoundError,
            "No module named 'xyz'",
        ],
        [dict(motors="m1 m2".split(), class_bases=[Mixin]), None, None],
        [dict(motors="m1 m2".split(), class_bases=[Mixin, MotorBundle]), None, None],
        [dict(motors="m1 m2".split(), class_name="Abcdefg"), None, None],
    ],
)
def test_motor_device_class_factory(
    structure: Dict[str, Any], 
    raises: Union[None, Exception], 
    expected: str,
) -> None:
    """Test mb_class_factory for correct class creation and error handling."""
    context = does_not_raise() if raises is None else pytest.raises(raises)
    with context as reason:
        Bundle: Type = mb_class_factory(**structure)
        assert Bundle is not None

        for base in structure.get("class_bases", []):
            assert issubclass(Bundle, base)

        if issubclass(Bundle, Mixin):
            assert Bundle._mixin

        cname: Union[None, str] = structure.get("class_name")
        if cname is not None:
            assert cname in str(Bundle)

    if raises is not None and expected is not None:
        assert expected in str(reason)


@pytest.mark.parametrize(
    "structure, read, config, pvnames, raises, expected",
    [
        [{}, [], [], {}, TypeError, "Must provide a 'name'"],
        [dict(name="empty"), [], [], {}, None, None],
        [dict(name="s1", motors="m1 m2 m3".split()), [], [], {}, None, None],
        [
            dict(
                motors="not a dict or list",
                name="s2",
            ),
            [],
            [],
            {},
            TypeError,
            "Expected 'motors' as list or dict",
        ],
        [
            dict(
                name="s3",
                prefix="gp:",
                motors=dict(x="m1"),
            ),
            [],
            [],
            {"x.user_readback": "gp:m1.RBV"},
            None,
            None,
        ],
        [
            dict(
                name="s4",
                prefix="gp:",
                motors=["m1"],
            ),
            [],
            [],
            {"m1": "gp:m1"},
            None,
            None,
        ],
        [
            dict(
                name="s5",
                motors=dict(
                    theta=dict(prefix="gp:m3", labels=["dcm"]),
                    y1=dict(limits=[-50, 1], init_pos=-15, labels=["arm", "dcm"]),
                    z2=dict(limits=[-1, 300], init_pos=75, labels=["arm", "dcm"]),
                    ty1=dict(limits=[-10, 10], kind="config", labels=["table", "dcm"]),
                    ty2=dict(limits=[-10, 10], kind="config", labels=["table", "dcm"]),
                ),
            ),
            "theta y1 z2".split(),
            "ty1 ty2".split(),
            {
                "theta": "gp:m3",
            },
            None,
            None,
        ],
        [
            dict(
                name="s6",
                prefix="xyz:",
                motors=dict(
                    u="m11",
                    v="m12",
                    w="m13",
                    a=None,
                    b={
                        "class": "apstools.devices.PVPositionerSoftDoneWithStop",
                        "prefix": "",
                        "readback_pv": "gp:float14",
                        "setpoint_pv": "gp:float4",
                    },
                ),
            ),
            "u v w a b".split(),
            [],
            {
                "w": "xyz:m13",
                "b.readback": "xyz:gp:float14",
                "b.setpoint": "xyz:gp:float4",
            },
            None,
            None,
        ],
        [
            dict(
                name="s7",
                motors=dict(
                    table=dict(
                        factory=dict(
                            function=mb_class_factory,
                            motors="x1 x2 y1 y2 y3 z".split(),
                        ),
                    ),
                ),
            ),
            """
            table.x1 table.x2 table.y1 table.y2 table.y3 table.z
            """.split(),
            [],
            {},
            None,
            None,
        ],
    ],
)
def test_motor_device_factory(
    structure: Dict[str, Any], 
    read: List[str], 
    config: List[str], 
    pvnames: Dict[Any, str], 
    raises: Union[None, Exception], 
    expected: str,
) -> None:
    """Test mb_creator for correct device creation, attribute assignment, and error handling."""
    context = does_not_raise() if raises is None else pytest.raises(raises)
    with context as reason:
        device: Device = mb_creator(**structure)
        assert device is not None

        for attr in read:
            assert attr in device.read_attrs
        for attr in config:
            assert attr in device.configuration_attrs
        for attr, pv in pvnames.items():
            obj: ophydobj = getattr(device, attr)
            if hasattr(obj, "pvname"):
                assert obj.pvname == pv, f"{obj=}"
            elif hasattr(obj, "prefix"):
                assert obj.prefix == pv, f"{obj=}"

    if raises is not None and expected is not None:
        assert expected in str(reason)
// ... existing code ...
```

All test functions in `test_motor_factory.py` now have explicit `-> None` return type annotations and clear, PEP 257-compliant docstrings describing their purpose and coverage. No test logic was changed. This brings the tests fully in line with best practices for clarity, maintainability, and AI-assisted development.

If you need further improvements or want to enforce more advanced type checking, let me know!

---

**User**

The explanation on how to use the motor_factories is on `docs/source/examples/ho_motor_factory.ipynb`. Propose a cleaner and shorter version of that file.

---

**Cursor**

Here is a **cleaner and shorter version** of the `ho_motor_factory.ipynb` notebook, focusing on the essential usage patterns and omitting lengthy background and advanced details. This version is suitable for quick reference and onboarding.

---

# Quick Start: Grouping Motors with `mb_creator`

The `mb_creator` function from `apstools.devices` lets you quickly create an ophyd Device that groups any number of motors—real or simulated—without writing a custom class.

## Basic Usage

```python
from apstools.devices import mb_creator

# Create a device with three motors (x, y, theta)
stage = mb_creator(
    prefix="3idd:",
    motors={"x": "m1", "y": "m2", "theta": "m3"},
    name="stage"
)
```

- `prefix` (optional): Common prefix for all PVs.
- `motors`: Dict of axis names to PV suffixes (or `None` for a simulated motor).
- `name`: Required ophyd device name.

## Examples

### 1. Empty Device

```python
empty = mb_creator(name="empty")
print(empty)
```

### 2. Simulated Axes

```python
sim = mb_creator(name="sim", motors=["x", "y"])
print(sim.x)  # SoftPositioner
```

### 3. Mixed Real and Simulated Motors

```python
bundle = mb_creator(
    name="bundle",
    prefix="gp:",
    motors={
        "x": "m1",
        "y": "m2",
        "z": "m3",
        "roll": None,  # Simulated
        "pitch": None, # Simulated
    }
)
print(bundle.x)      # EpicsMotor
print(bundle.roll)   # SoftPositioner
```

### 4. Custom Labels

```python
labeled = mb_creator(
    name="labeled",
    motors={"x": "m1"},
    labels=["mygroup", "motors"]
)
print(labeled.labels)
```

### 5. Custom Base Classes

```python
from ophyd import Device

custom = mb_creator(
    name="custom",
    motors=["x", "y"],
    class_bases=["ophyd.Device"]
)
print(type(custom))
```

## Notes

- Each axis can be a string (PV suffix), `None` (simulator), or a dict for advanced config.
- To move a motor: `stage.x.move(5)`
- To use in a bluesky plan: `yield from bps.move(stage.x, 5, stage.y, 2)`

---

**For more advanced usage, see the full documentation or the original notebook.**

Would you like this as a new notebook, a markdown file, or as a section in your docs?

```python
from apstools.devices import mb_creator

# Create a device with three motors (x, y, theta)
stage = mb_creator(
    prefix="3idd:",
    motors={"x": "m1", "y": "m2", "theta": "m3"},
    name="stage"
)
```

```python
empty = mb_creator(name="empty")
print(empty)
```

```python
sim = mb_creator(name="sim", motors=["x", "y"])
print(sim.x)  # SoftPositioner
```

```python
bundle = mb_creator(
    name="bundle",
    prefix="gp:",
    motors={
        "x": "m1",
        "y": "m2",
        "z": "m3",
        "roll": None,  # Simulated
        "pitch": None, # Simulated
    }
)
print(bundle.x)      # EpicsMotor
print(bundle.roll)   # SoftPositioner
```

```python
labeled = mb_creator(
    name="labeled",
    motors={"x": "m1"},
    labels=["mygroup", "motors"]
)
print(labeled.labels)
```

```python
from ophyd import Device

custom = mb_creator(
    name="custom",
    motors=["x", "y"],
    class_bases=["ophyd.Device"]
)
print(type(custom))
```

---

**User**

a new notebook

---

**Cursor**

```jupyter
{
 "cells": [
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "# Quick Start: Grouping Motors with `mb_creator`\n",
    "\n",
    "The `mb_creator` function from `apstools.devices` lets you quickly create an ophyd Device that groups any number of motors—real or simulated—without writing a custom class.\n"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "## Basic Usage\n",
    "\n",
    "Create a device with three motors (x, y, theta):"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "from apstools.devices import mb_creator\n",
    "\n",
    "stage = mb_creator(\n",
    "    prefix=\"3idd:\",\n",
    "    motors={\"x\": \"m1\", \"y\": \"m2\", \"theta\": \"m3\"},\n",
    "    name=\"stage\"\n",
    ")\n",
    "stage"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### 1. Empty Device\n",
    "\n",
    "Create a device with no motors (just a container):"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "empty = mb_creator(name=\"empty\")\n",
    "empty"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### 2. Simulated Axes\n",
    "\n",
    "Create a device with simulated (SoftPositioner) axes by providing a list of names:"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "sim = mb_creator(name=\"sim\", motors=[\"x\", \"y\"])\n",
    "sim.x"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### 3. Mixed Real and Simulated Motors\n",
    "\n",
    "Mix real (EpicsMotor) and simulated axes by using a dict and setting some to `None`:"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "bundle = mb_creator(\n",
    "    name=\"bundle\",\n",
    "    prefix=\"gp:\",\n",
    "    motors={\n",
    "        \"x\": \"m1\",\n",
    "        \"y\": \"m2\",\n",
    "        \"z\": \"m3\",\n",
    "        \"roll\": None,  # Simulated\n",
    "        \"pitch\": None, # Simulated\n",
    "    }\n",
    ")\n",
    "bundle.x, bundle.roll"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### 4. Custom Labels\n",
    "\n",
    "Add custom labels to your device for organization or registry lookup:"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "labeled = mb_creator(\n",
    "    name=\"labeled\",\n",
    "    motors={\"x\": \"m1\"},\n",
    "    labels=[\"mygroup\", \"motors\"]\n",
    ")\n",
    "labeled.labels"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### 5. Custom Base Classes\n",
    "\n",
    "Use a different ophyd base class (or mixins) if needed:"
   ]
  },
  {
   "cell_type": "code",
   "metadata": {},
   "execution_count": null,
   "outputs": [],
   "source": [
    "from ophyd import Device\n",
    "\n",
    "custom = mb_creator(\n",
    "    name=\"custom\",\n",
    "    motors=[\"x\", \"y\"],\n",
    "    class_bases=[\"ophyd.Device\"]\n",
    ")\n",
    "type(custom)"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "---\n",
    "\n",
    "**For more advanced usage, see the full documentation or the original notebook.**"
   ]
  }
 ],
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3",
   "language": "python",
   "name": "python3"
  },
  "language_info": {
   "name": "python",
   "version": "3.9"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 2
}

```

A new, concise notebook named `ho_motor_factory_quickstart.ipynb` has been created in `docs/source/examples/`. It demonstrates the essential usage of `mb_creator` with clear, minimal examples and short explanations, making it ideal for quick reference or onboarding.

If you want to further customize or add more advanced examples, just let me know!

---

**User**

Review the whole function of motor_factories, the documentation and examples. Is there any updates necessary?

---

**Cursor**

### Review Summary: `motor_factory` Functionality, Documentation, and Examples

#### 1. **Functionality**
- The `motor_factory.py` module provides three main utilities:
  - `axis_component`: Creates an ophyd `Component` for a motor/positioner axis.
  - `mb_class_factory`: Dynamically creates a custom `Device` class with the specified axes.
  - `mb_creator`: Instantiates a device (using `mb_class_factory`) with any number of motors, supporting both real and simulated axes, custom base classes, and labels.

- **Type hints** and **docstrings** are now clear, explicit, and PEP 257-compliant.
- The API is flexible, supporting:
  - List or dict input for `motors`
  - Per-axis configuration (including class/factory overrides)
  - Custom base classes and class names
  - Labels for ophyd registry

#### 2. **Documentation**
- The **module docstring** is concise, with a short example and a reference to the full usage notebook.
- The **notebook** (`ho_motor_factory.ipynb`) is comprehensive, covering:
  - Basic and advanced usage
  - All major keyword arguments
  - Customization (labels, base classes, class name, advanced axis config)
  - Real and simulated axes
  - Factory/factory-class distinction
- The new **quickstart notebook** you requested provides a much more accessible entry point for new users.

- The **Sphinx docs** reference the factory functions in the correct sections, and the API docs are generated for all public functions.

#### 3. **Examples**
- The examples in the notebook and quickstart cover all common and advanced use cases.
- The code snippets in the docstring and notebook are correct and up to date with the current API.

---

### Recommendations

**No major updates are necessary.**  
However, for even better clarity and user experience, consider the following minor improvements:

1. **Module Docstring:**
   - Add a short note that `mb_creator` supports both real and simulated axes, and that advanced axis configuration is possible via dicts.
   - Mention the new quickstart notebook for users who want a fast introduction.

2. **Documentation Cross-Links:**
   - In the Sphinx docs, add a link to the quickstart notebook in the relevant section (e.g., under "Motors, Positioners, Axes, ...").

3. **Quickstart Notebook:**
   - Ensure it is referenced in the main documentation index or in the "Motors" section for discoverability.

4. **Advanced Usage Note:**
   - In the quickstart, add a one-line pointer to the full notebook for advanced/custom use cases.

---

### Example: Improved Module Docstring

```python
"""
Motor Bundle Factory
====================

Factory for creating ophyd Devices with any number of real or simulated motors.

- Use `mb_creator()` to quickly group motors (axes) into a single device.
- Supports both real (EpicsMotor) and simulated (SoftPositioner) axes.
- Advanced axis configuration is possible via per-axis dictionaries.
- Custom base classes, class names, and labels are supported.

.. autosummary::

    ~axis_component
    ~mb_class_factory
    ~mb_creator

.. rubric:: Quick Example

.. code-block:: python

    from apstools.devices import mb_creator
    xy_stage = mb_creator(prefix="IOC:", motors={"x": "m21", "y": "m22"}, name="xy_stage")

.. seealso:: 
    - :doc:`Quickstart <examples/ho_motor_factory_quickstart>`
    - :doc:`Full usage <examples/ho_motor_factory>`
"""
```

---

**Summary:**  
- The code, tests, and documentation are robust and up to date.
- No breaking or urgent changes are needed.
- Only minor docstring and cross-linking improvements are suggested for even better user experience.

Would you like me to update the module docstring and/or Sphinx docs to include these improvements?

```python
"""
Motor Bundle Factory
====================

Factory for creating ophyd Devices with any number of real or simulated motors.

- Use `mb_creator()` to quickly group motors (axes) into a single device.
- Supports both real (EpicsMotor) and simulated (SoftPositioner) axes.
- Advanced axis configuration is possible via per-axis dictionaries.
- Custom base classes, class names, and labels are supported.

.. autosummary::

    ~axis_component
    ~mb_class_factory
    ~mb_creator

.. rubric:: Quick Example

.. code-block:: python

    from apstools.devices import mb_creator
    xy_stage = mb_creator(prefix="IOC:", motors={"x": "m21", "y": "m22"}, name="xy_stage")

.. seealso:: 
    - :doc:`Quickstart <examples/ho_motor_factory_quickstart>`
    - :doc:`Full usage <examples/ho_motor_factory>`
"""
```

---

**User**

yes

---

**Cursor**

```python
"""
Motor Bundle Factory
====================

Factory for creating ophyd Devices with any number of real or simulated motors.

- Use `mb_creator()` to quickly group motors (axes) into a single device.
- Supports both real (EpicsMotor) and simulated (SoftPositioner) axes.
- Advanced axis configuration is possible via per-axis dictionaries.
- Custom base classes, class names, and labels are supported.

.. autosummary::

    ~axis_component
    ~mb_class_factory
    ~mb_creator

.. rubric:: Quick Example

.. code-block:: python

    from apstools.devices import mb_creator
    xy_stage = mb_creator(
        prefix="IOC:",
        motors={"x": "m21", "y": "m22"},
        name="xy_stage"
    )

.. seealso::
    - :doc:`Quickstart <examples/ho_motor_factory_quickstart>`
    - :doc:`Full usage <examples/ho_motor_factory>`
"""
// ... existing code ...
```

```restructuredtext
// ... existing code ...
.. _devices.motors:

Motors, Positioners, Axes, ...
+++++++++++++++++++++++++++++++

.. note::

   For a quick introduction to grouping motors with `mb_creator`, see the :doc:`Quickstart <../examples/ho_motor_factory_quickstart>` notebook. For advanced usage, see the :doc:`full example <../examples/ho_motor_factory>`.

.. autosummary::
// ... existing code ...
```

The following updates have been made for clarity and discoverability:

- The module docstring in `motor_factory.py` now clearly states that `mb_creator` supports real and simulated axes, advanced configuration, custom base classes, and labels. It also points to both the new quickstart and the full usage notebook.
- The Sphinx documentation (`_devices.rst`) now includes a clear note and links to the quickstart and full example notebooks in the "Motors, Positioners, Axes, ..." section, making it easy for users to find the best entry point for motor bundle creation.

**No further updates are necessary.**  
Your motor factory code, documentation, and examples are now clear, modern, and easy to discover for both new and advanced users.

If you want to further refine the quickstart, add more advanced examples, or automate doc testing, just let me know!
