### PR TITLE
drop Py3.9 from test suite

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -49,11 +49,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"  # TODO: upstream packages not yet ready
       max-parallel: 5
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,11 @@ describe future plans.
 
    * Fix issue where extra data point  written in specwriter when baseline stream. was present 
 
+   Maintenance
+   -----------
+
+   * Now testing with Python versions 3.10 - Py3.13. (still pinning databroker)
+
 1.7.7
 *****
 


### PR DESCRIPTION
-closes #1125

As noted in #1124, unrelated unit test failures are expected, to be resolved in other work.  Will merge anyway.