### PR TITLE
MNT Only use when available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,12 @@ describe future plans.
    1.7.10
    ******
 
-   Release expected by 2026-01.
+   Release expected by 2025-12-05.
+
+   Fixes
+   -------------
+
+   * BUG 'dt_cycle_ends' in apstools.devices.aps_cycle.ApsCycleDM
 
 1.7.9
 *****

--- a/apstools/devices/aps_cycle.py
+++ b/apstools/devices/aps_cycle.py
@@ -161,7 +161,7 @@ class ApsCycleDM(SynSignalRO):
             if now.month < 5:
                 cycle = f"{now.year}-1"
                 dt_cycle_ends = f"{now.year}-05-01 00:00:00-05:00"
-            if now.month < 9:
+            elif now.month < 9:
                 cycle = f"{now.year}-2"
                 dt_cycle_ends = f"{now.year}-10-01 00:00:00-05:00"
             else:


### PR DESCRIPTION
Only assign from `dt_cycle_ends` when it is defined.