### PR TITLE
MNT #1081: replace autosummary with sphinx-autoapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 *.tar.gz
 *.whl
 docs/build/
+docs/source/api/autoapi/
 .settings/
 build/
 .ipynb_checkpoints/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Example: `1150-full-run-uid-to-dm`
 - Place entries under the appropriate (possibly still-commented-out) upcoming release section.
 - Use the correct subsection heading (`Enhancements`, `Fixes`, `Maintenance`, etc.).
 - Reference the issue number with the RST role `` (:issue:`<number>`) ``.
+- Keep entries within each subsection sorted alphabetically by the first significant word.
 - Keep the release date in the upcoming section in sync with the due date on the corresponding GitHub milestone.
 
 Example:
@@ -122,6 +123,32 @@ In the PR body, link related issues with a markdown bullet list:
 ```
 
 Use `Closes #N` to auto-close the issue when the PR is merged.
+
+## API Documentation Bullet Lists
+
+The curated API topic pages under `docs/source/api/` (`_callbacks.rst`,
+`_devices.rst`, `_filewriters.rst`, `_plans.rst`, `_utils.rst`, and
+`synApps/index.rst`) use hand-maintained bullet lists of the form:
+
+```rst
+* :func:`~apstools.plans.alignment.lineup2` — align a mover to a peak
+* :class:`~apstools.plans.alignment.TuneAxis` — tune a single axis
+```
+
+These lists are intentionally maintained by agents, not auto-generated.
+When adding, removing, or renaming public API symbols:
+
+- Add a bullet for every new public function, class, or constant in the
+  appropriate section of the relevant curated RST file.
+- Remove the bullet when a symbol is deleted or made private.
+- Update the one-liner when a symbol's purpose changes significantly.
+- Use `:func:` for functions, `:class:` for classes, `:data:` for
+  module-level constants, `:meth:` for methods.
+- The tilde (`~`) in the role target suppresses the module path in the
+  rendered link text, showing only the symbol name.
+- Keep the one-liner to a single short sentence — it is the user's first
+  signal about whether to click through.
+- Keep entries within each section sorted alphabetically by symbol name.
 
 ## Do Not
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,11 +29,11 @@ describe future plans.
    Enhancements
    ------------
 
-   * Add full bluesky run ``uid`` (as ``bluesky_run_uid``) to metadata shared with APS DM. (:issue:`1150`)
    * ``lineup2()`` now writes peak statistics (including ``success`` and
      ``reasons``) as a bluesky stream before the run closes.  Stream name
      is controlled by the new ``stats_stream`` kwarg (default:
      ``"signal_stats"``). (:issue:`1046`)
+   * Add full bluesky run ``uid`` (as ``bluesky_run_uid``) to metadata shared with APS DM. (:issue:`1150`)
 
    Fixes
    -------------
@@ -46,19 +46,24 @@ describe future plans.
    Maintenance
    -----------
 
-   * Relocate some utils code from apsbits.
+   * Add tests verifying ``EmailNotifications`` sends correctly via SMTP. (:issue:`1112`)
+   * Add unit tests for ``SignalStatsCallback``. (:issue:`1072`)
    * Bump minimum Python version to 3.10 (Python 3.9 is EOL). (:issue:`1150`)
    * Consolidate ruff configuration into ``pyproject.toml``, removing ``.ruff.toml``. (:issue:`1150`)
-   * Add tests verifying ``EmailNotifications`` sends correctly via SMTP. (:issue:`1112`)
+   * Move test catalogs from ``resources/`` to ``apstools/tests/`` and drop
+     ``_test`` suffix from file names. (:issue:`1165`)
    * Refactor test catalog installation to use in-memory ``databroker.temp()``
      loaded from ``.json.gz`` snapshots, removing the fragile ``databroker-unpack``
      / msgpack / intake YAML approach.  Re-enable 20 skipped tests. (:issue:`1131`)
+   * Replace ``sphinx.ext.autosummary`` and ``.. automodule::`` directives with
+     ``sphinx-autoapi`` for auto-generated API reference.  Curated topic pages
+     (Callbacks, Devices, File Writers, Plans, Utilities, synApps) are retained
+     as bullet-list indexes that cross-reference into the auto-generated pages.
+     (:issue:`1081`)
    * Review and refactor unit tests: remove ``try/except`` anti-patterns, use
      ``parms, context`` parametrize style, add ``re.escape()`` to ``match=``
      strings, replace ``os.chdir()`` with ``monkeypatch.chdir()``. (:issue:`1154`)
-   * Move test catalogs from ``resources/`` to ``apstools/tests/`` and drop
-     ``_test`` suffix from file names. (:issue:`1165`)
-   * Add unit tests for ``SignalStatsCallback``. (:issue:`1072`)
+   * Relocate some utils code from apsbits.
 
 1.7.9
 *****

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,3 +1,15 @@
+/* Hide the full module-path prefix in autoapi signature blocks.
+   The full import path is shown via "Import:" below each signature. */
+.sig-prename.descclassname {
+    display: none;
+}
+
+/* Remove extra margin from the Import: container so it
+   aligns with Bases: and the docstring text. */
+.import-path.docutils.container {
+    margin: 0;
+}
+
 /* Style the link marked: latest */
 .version-switcher__container a[data-version-name*="(latest)"] {
     background-color: lightgreen;

--- a/docs/source/_templates/autoapi/index.rst
+++ b/docs/source/_templates/autoapi/index.rst
@@ -1,0 +1,13 @@
+API Reference
+=============
+
+This page contains auto-generated API reference documentation [#f1]_.
+
+.. toctree::
+   :titlesonly:
+
+   {% for page in pages|selectattr("is_top_level_object") %}
+   {{ page.include_path }}
+   {% endfor %}
+
+.. [#f1] Created with `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`_

--- a/docs/source/_templates/autoapi/python/attribute.rst
+++ b/docs/source/_templates/autoapi/python/attribute.rst
@@ -1,0 +1,1 @@
+{% extends "python/data.rst" %}

--- a/docs/source/_templates/autoapi/python/class.rst
+++ b/docs/source/_templates/autoapi/python/class.rst
@@ -1,0 +1,111 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name | length }}
+
+``{{ obj.id }}{% if obj.args %}({{ obj.args }}){% endif %}``
+
+   {% endif %}
+   {% set visible_children = obj.children|selectattr("display")|list %}
+   {% set own_page_children = visible_children|selectattr("type", "in", own_page_types)|list %}
+   {% if is_own_page and own_page_children %}
+.. toctree::
+   :hidden:
+
+      {% for child in own_page_children %}
+   {{ child.include_path }}
+      {% endfor %}
+
+   {% endif %}
+.. py:{{ obj.type }}:: {{ obj.short_name }}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}{% if obj.args %}({{ obj.args }}){% endif %}
+
+   {% for (args, return_annotation) in obj.overloads %}
+      {{ " " * (obj.type | length) }}   {{ obj.short_name }}{% if args %}({{ args }}){% endif %}
+
+   {% endfor %}
+
+   .. container:: import-path
+
+      Import: ``{{ obj.id }}``
+
+   {% if obj.bases %}
+      {% if "show-inheritance" in autoapi_options %}
+
+   Bases: {% for base in obj.bases %}{{ base|link_objs }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+
+
+      {% if "show-inheritance-diagram" in autoapi_options and obj.bases != ["object"] %}
+   .. autoapi-inheritance-diagram:: {{ obj.obj["full_name"] }}
+      :parts: 1
+         {% if "private-members" in autoapi_options %}
+      :private-bases:
+         {% endif %}
+
+      {% endif %}
+   {% endif %}
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+   {% for obj_item in visible_children %}
+      {% if obj_item.type not in own_page_types %}
+
+   {{ obj_item.render()|indent(3) }}
+      {% endif %}
+   {% endfor %}
+   {% if is_own_page and own_page_children %}
+      {% set visible_attributes = own_page_children|selectattr("type", "equalto", "attribute")|list %}
+      {% if visible_attributes %}
+Attributes
+----------
+
+.. autoapisummary::
+
+         {% for attribute in visible_attributes %}
+   {{ attribute.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_exceptions = own_page_children|selectattr("type", "equalto", "exception")|list %}
+      {% if visible_exceptions %}
+Exceptions
+----------
+
+.. autoapisummary::
+
+         {% for exception in visible_exceptions %}
+   {{ exception.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_classes = own_page_children|selectattr("type", "equalto", "class")|list %}
+      {% if visible_classes %}
+Classes
+-------
+
+.. autoapisummary::
+
+         {% for klass in visible_classes %}
+   {{ klass.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_methods = own_page_children|selectattr("type", "equalto", "method")|list %}
+      {% if visible_methods %}
+Methods
+-------
+
+.. autoapisummary::
+
+            {% for method in visible_methods %}
+   {{ method.id }}
+            {% endfor %}
+
+
+      {% endif %}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/data.rst
+++ b/docs/source/_templates/autoapi/python/data.rst
@@ -1,0 +1,45 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:{% if obj.is_type_alias() %}type{% else %}{{ obj.type }}{% endif %}:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.name }}{% endif %}
+   {% if obj.is_type_alias() %}
+      {% if obj.value %}
+
+   :canonical: {{ obj.value }}
+      {% endif %}
+   {% else %}
+      {% if obj.annotation is not none %}
+
+   :type: {% if obj.annotation %} {{ obj.annotation }}{% endif %}
+      {% endif %}
+      {% if obj.value is not none %}
+
+         {% if obj.value.splitlines()|count > 1 %}
+   :value: Multiline-String
+
+   .. raw:: html
+
+      <details><summary>Show Value</summary>
+
+   .. code-block:: python
+
+      {{ obj.value|indent(width=6,blank=true) }}
+
+   .. raw:: html
+
+      </details>
+
+         {% else %}
+   :value: {{ obj.value|truncate(100) }}
+         {% endif %}
+      {% endif %}
+   {% endif %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/exception.rst
+++ b/docs/source/_templates/autoapi/python/exception.rst
@@ -1,0 +1,1 @@
+{% extends "python/class.rst" %}

--- a/docs/source/_templates/autoapi/python/function.rst
+++ b/docs/source/_templates/autoapi/python/function.rst
@@ -1,0 +1,28 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name | length }}
+
+``{{ obj.id }}({{ obj.args }}){% if obj.return_annotation is not none %} → {{ obj.return_annotation }}{% endif %}``
+
+   {% endif %}
+.. py:function:: {{ obj.short_name }}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+
+   {% for (args, return_annotation) in obj.overloads %}
+                 {%+ if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+
+   {% endfor %}
+   {% for property in obj.properties %}
+   :{{ property }}:
+
+   {% endfor %}
+
+   .. container:: import-path
+
+      Import: ``{{ obj.id }}``
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/method.rst
+++ b/docs/source/_templates/autoapi/python/method.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:method:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+   {% for (args, return_annotation) in obj.overloads %}
+
+               {%+ if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+   {% endfor %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/module.rst
+++ b/docs/source/_templates/autoapi/python/module.rst
@@ -1,0 +1,157 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name|length }}
+
+.. py:module:: {{ obj.name }}
+
+.. autoapi-nested-parse::
+
+   Import: ``{{ obj.id }}``
+
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+
+      {% block submodules %}
+         {% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
+         {% set visible_submodules = obj.submodules|selectattr("display")|list %}
+         {% set visible_submodules = (visible_subpackages + visible_submodules)|sort %}
+         {% if visible_submodules %}
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 1
+
+            {% for submodule in visible_submodules %}
+   {{ submodule.include_path }}
+            {% endfor %}
+
+
+         {% endif %}
+      {% endblock %}
+      {% block content %}
+         {% set visible_children = obj.children|selectattr("display")|list %}
+         {% if visible_children %}
+            {% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
+            {% if visible_attributes %}
+               {% if "attribute" in own_page_types or "show-module-summary" in autoapi_options %}
+Attributes
+----------
+
+                  {% if "attribute" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for attribute in visible_attributes %}
+   {{ attribute.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for attribute in visible_attributes %}
+   {{ attribute.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_exceptions = visible_children|selectattr("type", "equalto", "exception")|list %}
+            {% if visible_exceptions %}
+               {% if "exception" in own_page_types or "show-module-summary" in autoapi_options %}
+Exceptions
+----------
+
+                  {% if "exception" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for exception in visible_exceptions %}
+   {{ exception.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for exception in visible_exceptions %}
+   {{ exception.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
+            {% if visible_classes %}
+               {% if "class" in own_page_types or "show-module-summary" in autoapi_options %}
+Classes
+-------
+
+                  {% if "class" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for klass in visible_classes %}
+   {{ klass.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for klass in visible_classes %}
+   {{ klass.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
+            {% if visible_functions %}
+               {% if "function" in own_page_types or "show-module-summary" in autoapi_options %}
+Functions
+---------
+
+                  {% if "function" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for function in visible_functions %}
+   {{ function.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for function in visible_functions %}
+   {{ function.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set this_page_children = visible_children|rejectattr("type", "in", own_page_types)|list %}
+            {% if this_page_children %}
+{{ obj.type|title }} Contents
+{{ "-" * obj.type|length }}---------
+
+               {% for obj_item in this_page_children %}
+{{ obj_item.render()|indent(0) }}
+               {% endfor %}
+            {% endif %}
+         {% endif %}
+      {% endblock %}
+   {% else %}
+.. py:module:: {{ obj.name }}
+
+      {% if obj.docstring %}
+   .. autoapi-nested-parse::
+
+      {{ obj.docstring|indent(6) }}
+
+      {% endif %}
+      {% for obj_item in visible_children %}
+   {{ obj_item.render()|indent(3) }}
+      {% endfor %}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/package.rst
+++ b/docs/source/_templates/autoapi/python/package.rst
@@ -1,0 +1,1 @@
+{% extends "python/module.rst" %}

--- a/docs/source/_templates/autoapi/python/property.rst
+++ b/docs/source/_templates/autoapi/python/property.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:property:: {% if is_own_page %}{{ obj.id}}{% else %}{{ obj.short_name }}{% endif %}
+   {% if obj.annotation %}
+
+   :type: {{ obj.annotation }}
+   {% endif %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/api/_callbacks.rst
+++ b/docs/source/api/_callbacks.rst
@@ -7,26 +7,34 @@ Callbacks
 Receive *documents* from the bluesky RunEngine.
 :ref:`filewriters` are a specialized type of callback.
 
-.. rubric:: Callbacks
-.. autosummary::
-    :nosignatures:
+For complete API details see the :doc:`Full API Reference <autoapi/apstools/index>`.
 
-    ~apstools.callbacks.doc_collector.DocumentCollectorCallback
-    ~apstools.callbacks.doc_collector.document_contents_callback
-    ~apstools.callbacks.scan_signal_statistics.SignalStatsCallback
+.. rubric:: Callbacks
+
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
+
+   * - :func:`~apstools.callbacks.doc_collector.document_contents_callback`
+     - print document contents for diagnosing a document stream
+   * - :class:`~apstools.callbacks.doc_collector.DocumentCollectorCallback`
+     - collect *all* documents from the most-recent plan
+   * - :class:`~apstools.callbacks.scan_signal_statistics.SignalStatsCallback`
+     - collect peak and other statistics during a scan
+
 
 .. rubric:: File Writing Callbacks
-.. autosummary::
-    :nosignatures:
 
-   ~apstools.callbacks.nexus_writer.NXWriterAPS
-   ~apstools.callbacks.nexus_writer.NXWriter
-   ~apstools.callbacks.spec_file_writer.SpecWriterCallback
-   ~apstools.callbacks.spec_file_writer.SpecWriterCallback2
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-.. automodule:: apstools.callbacks.doc_collector
-    :members:
+   * - :class:`~apstools.callbacks.nexus_writer.NXWriter`
+     - write HDF5/NeXus file using NeXus base classes
+   * - :class:`~apstools.callbacks.nexus_writer.NXWriterAPS`
+     - customize :class:`~apstools.callbacks.nexus_writer.NXWriter` with APS-specific content
+   * - :class:`~apstools.callbacks.spec_file_writer.SpecWriterCallback`
+     - (*deprecated*) write SPEC data file line-by-line
+   * - :class:`~apstools.callbacks.spec_file_writer.SpecWriterCallback2`
+     - write SPEC data file as data is collected, line-by-line
 
-.. automodule:: apstools.callbacks.scan_signal_statistics
-    :members:
-    :private-members:

--- a/docs/source/api/_devices.rst
+++ b/docs/source/api/_devices.rst
@@ -6,6 +6,8 @@ Devices
 
 Ophyd-style Devices for the APS.
 
+For complete API details see the :doc:`Full API Reference <autoapi/apstools/index>`.
+
 Also consult the :ref:`Index <genindex>` under the *Ophyd* heading for
 links to the Devices, Exceptions, Mixins, Signals, and other support
 items described here.
@@ -32,68 +34,119 @@ See these categories:
 APS General Support
 +++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.aps_cycle.ApsCycleDM
-    ~apstools.devices.aps_machine.ApsMachineParametersDevice
-    ~apstools.devices.shutters.ApsPssShutter
-    ~apstools.devices.shutters.ApsPssShutterWithStatus
-    ~apstools.devices.shutters.SimulatedApsPssShutterWithStatus
+   * - :class:`~apstools.devices.aps_cycle.ApsCycleDM`
+     - get the APS cycle name from a local file (source: official APS schedule)
+   * - :class:`~apstools.devices.aps_machine.ApsMachineParametersDevice`
+     - common operational parameters of the APS of general interest
+   * - :class:`~apstools.devices.shutters.ApsPssShutter`
+     - APS PSS shutter
+   * - :class:`~apstools.devices.shutters.ApsPssShutterWithStatus`
+     - APS PSS shutter with separate status PV
+   * - :class:`~apstools.devices.shutters.SimulatedApsPssShutterWithStatus`
+     - simulated APS PSS shutter
+
 
 .. _devices.area_detector:
 
 Area Detector Support
 +++++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.area_detector_factory.ad_creator
-    ~apstools.devices.area_detector_factory.ad_class_factory
+   * - :func:`~apstools.devices.area_detector_factory.ad_class_factory`
+     - build an area detector class with specified plugins
+   * - :func:`~apstools.devices.area_detector_factory.ad_creator`
+     - create an area detector object from a custom class
 
-.. rubric: Plugins
 
-.. autosummary::
+.. rubric:: Plugins
 
-    ~apstools.devices.area_detector_support.AD_EpicsFileNameHDF5Plugin
-    ~apstools.devices.area_detector_support.AD_EpicsFileNameJPEGPlugin
-    ~apstools.devices.area_detector_support.AD_EpicsFileNameTIFFPlugin
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-.. rubric: Mix-in classes
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsFileNameHDF5Plugin`
+     - HDF5 plugin: EPICS area detector PV sets file name
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsFileNameJPEGPlugin`
+     - JPEG plugin: EPICS area detector PV sets file name
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsFileNameTIFFPlugin`
+     - TIFF plugin: EPICS area detector PV sets file name
 
-.. autosummary::
-    ~apstools.devices.area_detector_support.AD_EpicsFileNameMixin
-    ~apstools.devices.area_detector_support.AD_EpicsHdf5FileName
-    ~apstools.devices.area_detector_support.AD_EpicsHDF5IterativeWriter
-    ~apstools.devices.area_detector_support.AD_EpicsJPEGFileName
-    ~apstools.devices.area_detector_support.AD_EpicsJPEGIterativeWriter
-    ~apstools.devices.area_detector_support.AD_EpicsTIFFFileName
-    ~apstools.devices.area_detector_support.AD_EpicsTIFFIterativeWriter
-    ~apstools.devices.area_detector_support.AD_setup_FrameType
-    ~apstools.devices.area_detector_support.BadPixelPlugin
-    ~apstools.devices.area_detector_support.CamMixin_V34
-    ~apstools.devices.area_detector_support.CamMixin_V3_1_1
-    ~apstools.devices.area_detector_support.SingleTrigger_V34
 
-.. rubric: Other support
+.. rubric:: Mix-in classes
 
-.. autosummary::
-    ~apstools.devices.area_detector_support.AD_full_file_name_local
-    ~apstools.devices.area_detector_support.AD_plugin_primed
-    ~apstools.devices.area_detector_support.AD_prime_plugin2
-    ~apstools.devices.area_detector_support.ensure_AD_plugin_primed
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
+
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsFileNameMixin`
+     - custom class to define image file name from EPICS
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsHdf5FileName`
+     - custom class to define HDF5 image file name from EPICS PVs
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsHDF5IterativeWriter`
+     - intermediate class between AD_EpicsHdf5FileName and AD_EpicsFileNameHDF5Plugin
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsJPEGFileName`
+     - custom class to define JPEG image file name from EPICS PVs
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsJPEGIterativeWriter`
+     - intermediate class between AD_EpicsJPEGFileName and AD_EpicsFileNameJPEGPlugin
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsTIFFFileName`
+     - custom class to define TIFF image file name from EPICS PVs
+   * - :class:`~apstools.devices.area_detector_support.AD_EpicsTIFFIterativeWriter`
+     - intermediate class between AD_EpicsTIFFFileName and AD_EpicsFileNameTIFFPlugin
+   * - :class:`~apstools.devices.area_detector_support.BadPixelPlugin`
+     - ADCore NDBadPixel plugin, new in AD 3.13
+   * - :class:`~apstools.devices.area_detector_support.CamMixin_V34`
+     - update cam support to AD release 3.4
+   * - :class:`~apstools.devices.area_detector_support.CamMixin_V3_1_1`
+     - update cam support to AD release 3.1.1
+   * - :class:`~apstools.devices.area_detector_support.SingleTrigger_V34`
+     - variation of ophyd's SingleTrigger mixin supporting AcquireBusy
+
+
+.. rubric:: Other support
+
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
+
+   * - :func:`~apstools.devices.area_detector_support.AD_full_file_name_local`
+     - return AD plugin's last filename using local filesystem path
+   * - :func:`~apstools.devices.area_detector_support.AD_plugin_primed`
+     - check whether an NDArray has been pushed to the file writer plugin
+   * - :func:`~apstools.devices.area_detector_support.AD_prime_plugin2`
+     - prime this area detector's file writer plugin
+   * - :func:`~apstools.devices.area_detector_support.AD_setup_FrameType`
+     - configure frames to be identified and handled by type
+   * - :func:`~apstools.devices.area_detector_support.ensure_AD_plugin_primed`
+     - ensure the AD file writing plugin is primed, if allowed
+
 
 .. _devices.scalers:
 
 Detector & Scaler Support
 +++++++++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.struck3820.Struck3820
-    ~apstools.devices.measComp_usb_ctr_support.MeasCompCtr
-    ~apstools.devices.measComp_usb_ctr_support.MeasCompCtrMcs
-    ~apstools.devices.scaler_support.use_EPICS_scaler_channels
-    ~apstools.devices.synth_pseudo_voigt.SynPseudoVoigt
+   * - :class:`~apstools.devices.measComp_usb_ctr_support.MeasCompCtr`
+     - Measurement Computing USB CTR08 high-speed counter/timer
+   * - :class:`~apstools.devices.measComp_usb_ctr_support.MeasCompCtrMcs`
+     - Measurement Computing USB CTR08 multi-channel scaler controls
+   * - :class:`~apstools.devices.struck3820.Struck3820`
+     - Struck/SIS 3820 multi-channel scaler (as used by USAXS)
+   * - :class:`~apstools.devices.synth_pseudo_voigt.SynPseudoVoigt`
+     - evaluate a point on a pseudo-Voigt based on the value of a motor
+   * - :func:`~apstools.devices.scaler_support.use_EPICS_scaler_channels`
+     - configure scaler for only the channels with names assigned in EPICS
+
 
 .. tip:: The Measurement Computing USB-CTR08 EPICS support
     provides a compatible EPICS scaler record.
@@ -107,33 +160,38 @@ Factory Functions
 
 Object factories create ophyd objects.
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.area_detector_factory.ad_creator
-    ~apstools.devices.dict_device_support.make_dict_device
-    ~apstools.devices.motor_factory.mb_creator
+   * - :func:`~apstools.devices.area_detector_factory.ad_creator`
+     - create an area detector object from a custom class
+   * - :func:`~apstools.devices.dict_device_support.make_dict_device`
+     - make a recordable DictionaryDevice instance from a dictionary
+   * - :func:`~apstools.devices.motor_factory.mb_creator`
+     - create a MotorBundle with any number of motors
+
 
 .. rubric:: Class Factories
 
 Class factories create ophyd Device classes.
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.area_detector_factory.ad_class_factory
-    ~apstools.devices.dict_device_support.dict_device_factory
-    ~apstools.devices.motor_factory.mb_class_factory
+   * - :func:`~apstools.devices.area_detector_factory.ad_class_factory`
+     - build an area detector class with specified plugins
+   * - :func:`~apstools.devices.dict_device_support.dict_device_factory`
+     - create a DictionaryDevice class using the supplied dictionary
+   * - :func:`~apstools.devices.motor_factory.mb_class_factory`
+     - create a custom MotorBundle (or specified base) class
+
 
 .. _devices.flyers:
 
 Fly Scan Support
-+++++++++++++++++++++++
-
-.. issue #763
-    .. autosummary::
-
-        ~apstools.devices.flyer_motor_scaler.FlyerBase
-        ~apstools.devices.flyer_motor_scaler.ActionsFlyerBase
-        ~apstools.devices.flyer_motor_scaler.ScalerMotorFlyer
+++++++++++++++++
 
 ``ScalerMotorFlyer()`` support withdrawn pending issue #763.
 
@@ -142,13 +200,21 @@ Fly Scan Support
 Insertion Devices
 +++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.aps_undulator.PlanarUndulator
-    ~apstools.devices.aps_undulator.Revolver_Undulator
-    ~apstools.devices.aps_undulator.STI_Undulator
-    ~apstools.devices.aps_undulator.Undulator2M
-    ~apstools.devices.aps_undulator.Undulator4M
+   * - :class:`~apstools.devices.aps_undulator.PlanarUndulator`
+     - APS planar undulator
+   * - :class:`~apstools.devices.aps_undulator.Revolver_Undulator`
+     - APS revolver insertion device
+   * - :class:`~apstools.devices.aps_undulator.STI_Undulator`
+     - APS planar undulator built by STI Optronics
+   * - :class:`~apstools.devices.aps_undulator.Undulator2M`
+     - APS 2M undulator
+   * - :class:`~apstools.devices.aps_undulator.Undulator4M`
+     - APS 4M undulator
+
 
 .. note:: The ``ApsUndulator`` and ``ApsUndulatorDual`` device support
     classes have been removed.  These devices are not used in the APS-U era.
@@ -158,364 +224,216 @@ Insertion Devices
 Motors, Positioners, Axes, ...
 +++++++++++++++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.acs_motors.AcsMotor
-    ~apstools.devices.axis_tuner.AxisTunerException
-    ~apstools.devices.axis_tuner.AxisTunerMixin
-    ~apstools.devices.description_mixin.EpicsDescriptionMixin
-    ~apstools.devices.motor_factory.mb_class_factory
-    ~apstools.devices.motor_factory.mb_creator
-    ~apstools.devices.motor_mixins.EpicsMotorDialMixin
-    ~apstools.devices.motor_mixins.EpicsMotorEnableMixin
-    ~apstools.devices.motor_mixins.EpicsMotorRawMixin
-    ~apstools.devices.motor_mixins.EpicsMotorResolutionMixin
-    ~apstools.devices.motor_mixins.EpicsMotorServoMixin
-    ~apstools.devices.positioner_soft_done.PVPositionerSoftDone
-    ~apstools.devices.positioner_soft_done.PVPositionerSoftDoneWithStop
-    ~apstools.devices.shutters.EpicsMotorShutter
-    ~apstools.devices.shutters.EpicsOnOffShutter
-    ~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner
-    ~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner
+   * - :class:`~apstools.devices.acs_motors.AcsMotor`
+     - AcsMotionControl motor support
+   * - :class:`~apstools.devices.axis_tuner.AxisTunerException`
+     - exception during execution of AxisTunerBase subclass
+   * - :class:`~apstools.devices.axis_tuner.AxisTunerMixin`
+     - mixin class to provide tuning capabilities for an axis
+   * - :class:`~apstools.devices.description_mixin.EpicsDescriptionMixin`
+     - add a record's description field to a Device, such as EpicsMotor
+   * - :class:`~apstools.devices.motor_mixins.EpicsMotorDialMixin`
+     - add motor record's dial coordinate fields to Device
+   * - :class:`~apstools.devices.motor_mixins.EpicsMotorEnableMixin`
+     - mixin providing access to motor enable/disable
+   * - :class:`~apstools.devices.motor_mixins.EpicsMotorRawMixin`
+     - add motor record's raw coordinate fields to Device
+   * - :class:`~apstools.devices.motor_mixins.EpicsMotorResolutionMixin`
+     - add motor record's resolution fields to motor
+   * - :class:`~apstools.devices.motor_mixins.EpicsMotorServoMixin`
+     - add motor record's servo loop controls to Device
+   * - :class:`~apstools.devices.shutters.EpicsMotorShutter`
+     - shutter implemented with an EPICS motor moved between two positions
+   * - :class:`~apstools.devices.shutters.EpicsOnOffShutter`
+     - shutter using a single EPICS PV moved between two positions
+   * - :func:`~apstools.devices.motor_factory.mb_class_factory`
+     - create a custom MotorBundle (or specified base) class
+   * - :func:`~apstools.devices.motor_factory.mb_creator`
+     - create a MotorBundle with any number of motors
+   * - :class:`~apstools.devices.positioner_soft_done.PVPositionerSoftDone`
+     - PVPositioner that computes ``done`` as a soft signal
+   * - :class:`~apstools.devices.positioner_soft_done.PVPositionerSoftDoneWithStop`
+     - PVPositionerSoftDone with stop() and inposition
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner`
+     - simulated process controller as positioner with EPICS swait record
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner`
+     - simulated process controller as positioner with EPICS transform record
+
 
 .. _devices.shutters:
 
 Shutters
 ++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.shutters.ApsPssShutter
-    ~apstools.devices.shutters.ApsPssShutterWithStatus
-    ~apstools.devices.shutters.EpicsMotorShutter
-    ~apstools.devices.shutters.EpicsOnOffShutter
-    ~apstools.devices.shutters.OneSignalShutter
-    ~apstools.devices.shutters.ShutterBase
-    ~apstools.devices.shutters.SimulatedApsPssShutterWithStatus
+   * - :class:`~apstools.devices.shutters.ApsPssShutter`
+     - APS PSS shutter
+   * - :class:`~apstools.devices.shutters.ApsPssShutterWithStatus`
+     - APS PSS shutter with separate status PV
+   * - :class:`~apstools.devices.shutters.EpicsMotorShutter`
+     - shutter implemented with an EPICS motor moved between two positions
+   * - :class:`~apstools.devices.shutters.EpicsOnOffShutter`
+     - shutter using a single EPICS PV moved between two positions
+   * - :class:`~apstools.devices.shutters.OneSignalShutter`
+     - shutter Device using one Signal for open and close
+   * - :class:`~apstools.devices.shutters.ShutterBase`
+     - base class for all shutter Devices
+   * - :class:`~apstools.devices.shutters.SimulatedApsPssShutterWithStatus`
+     - simulated APS PSS shutter
+
 
 .. _devices.slits:
 
 Slits
-++++++++
++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.hhl_slits.HHLSlits
-    ~apstools.devices.xia_slit.XiaSlit2D
-    ~apstools.synApps.db_2slit.Optics2Slit1D
-    ~apstools.synApps.db_2slit.Optics2Slit2D_HV
-    ~apstools.synApps.db_2slit.Optics2Slit2D_InbOutBotTop
-    ~apstools.synApps.db_2slit.Optics2Slit1D_soft
-    ~apstools.synApps.db_2slit.Optics2Slit2D_soft
-    ~apstools.utils.slit_core.SlitGeometry
+   * - :class:`~apstools.devices.hhl_slits.HHLSlits`
+     - high heat load slit
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit1D`
+     - EPICS synApps optics 2slit.db 1D support: xn, xp, size, center, sync
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit2D_HV`
+     - EPICS synApps optics 2slit.db 2D support: h.xn, h.xp, v.xn, v.xp
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit2D_InbOutBotTop`
+     - EPICS synApps optics 2slit.db 2D support: inb, out, bot, top
+   * - :class:`~apstools.utils.slit_core.SlitGeometry`
+     - slit size and center as a named tuple
+   * - :class:`~apstools.devices.xia_slit.XiaSlit2D`
+     - EPICS synApps optics xia_slit.db 2D support
+
 
 synApps Support
-++++++++++++++++++++
++++++++++++++++
 
-    See separate :ref:`synApps` section.
+See separate :ref:`synApps` section.
 
 .. _devices.temperature_controllers:
 
 Temperature Support
-+++++++++++++++++++++++
++++++++++++++++++++
 
 Controllers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.eurotherm_2216e.Eurotherm2216e
-    ~apstools.devices.lakeshore_controllers.LakeShore336Device
-    ~apstools.devices.lakeshore_controllers.LakeShore340Device
-    ~apstools.devices.linkam_controllers.Linkam_CI94_Device
-    ~apstools.devices.linkam_controllers.Linkam_T96_Device
-    ~apstools.devices.ptc10_controller.PTC10AioChannel
-    ~apstools.devices.ptc10_controller.PTC10RtdChannel
-    ~apstools.devices.ptc10_controller.PTC10TcChannel
-    ~apstools.devices.ptc10_controller.PTC10PositionerMixin
-    ~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner
-    ~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner
+   * - :class:`~apstools.devices.eurotherm_2216e.Eurotherm2216e`
+     - Eurotherm 2216e temperature controller
+   * - :class:`~apstools.devices.lakeshore_controllers.LakeShore336Device`
+     - LakeShore 336 temperature controller
+   * - :class:`~apstools.devices.lakeshore_controllers.LakeShore340Device`
+     - LakeShore 340 temperature controller
+   * - :class:`~apstools.devices.linkam_controllers.Linkam_CI94_Device`
+     - Linkam model CI94 temperature controller
+   * - :class:`~apstools.devices.linkam_controllers.Linkam_T96_Device`
+     - Linkam model T96 temperature controller
+   * - :class:`~apstools.devices.ptc10_controller.PTC10AioChannel`
+     - SRS PTC10 AIO module
+   * - :class:`~apstools.devices.ptc10_controller.PTC10PositionerMixin`
+     - mixin so SRS PTC10 can be used as a temperature positioner
+   * - :class:`~apstools.devices.ptc10_controller.PTC10RtdChannel`
+     - SRS PTC10 RTD module channel
+   * - :class:`~apstools.devices.ptc10_controller.PTC10TcChannel`
+     - SRS PTC10 thermocouple module channel
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner`
+     - simulated process controller as positioner with EPICS swait record
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner`
+     - simulated process controller as positioner with EPICS transform record
+
 
 Readers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.measComp_tc32_support.MeasCompTc32
+   * - :class:`~apstools.devices.measComp_tc32_support.MeasCompTc32`
+     - Measurement Computing TC-32 32-channel thermocouple reader
+
 
 .. _devices.other_support:
 
 Other Support
 +++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.aps_bss_user.ApsBssUserInfoDevice
-    ~apstools.devices.aps_data_management.DM_WorkflowConnector
-    ~apstools.devices.xia_pf4.Pf4FilterSingle
-    ~apstools.devices.xia_pf4.Pf4FilterDual
-    ~apstools.devices.xia_pf4.Pf4FilterTriple
-    ~apstools.devices.xia_pf4.Pf4FilterBank
-    ~apstools.devices.xia_pf4.Pf4FilterCommon
-    ~apstools.devices.xia_pf4.DualPf4FilterBox
-    ~apstools.devices.description_mixin.EpicsDescriptionMixin
-    ~apstools.devices.dict_device_support.dict_device_factory
-    ~apstools.devices.dict_device_support.make_dict_device
-    ~apstools.devices.epics_scan_id_signal.EpicsScanIdSignal
-    ~apstools.devices.measComp_usb_ctr_support.MeasCompCtr
-    ~apstools.devices.kohzu_monochromator.KohzuSeqCtl_Monochromator
-    ~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner
-    ~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner
-    ~apstools.devices.srs570_preamplifier.SRS570_PreAmplifier
-    ~apstools.devices.struck3820.Struck3820
-    ~apstools.devices.delay.DG645Delay
-    ~apstools.devices.labjack.LabJackBase
-    ~apstools.devices.labjack.LabJackT4
-    ~apstools.devices.labjack.LabJackT7
-    ~apstools.devices.labjack.LabJackT7Pro
-    ~apstools.devices.labjack.LabJackT8
+   * - :class:`~apstools.devices.aps_bss_user.ApsBssUserInfoDevice`
+     - provide current experiment info from the APS BSS
+   * - :class:`~apstools.devices.delay.DG645Delay`
+     - SRS DG-645 digital delay/pulse generator
+   * - :func:`~apstools.devices.dict_device_support.dict_device_factory`
+     - create a DictionaryDevice class using the supplied dictionary
+   * - :class:`~apstools.devices.aps_data_management.DM_WorkflowConnector`
+     - support for APS Data Management tools
+   * - :class:`~apstools.devices.xia_pf4.DualPf4FilterBox`
+     - (*legacy*, use :class:`~apstools.devices.xia_pf4.Pf4FilterDual`) dual XIA PF4 filter boxes
+   * - :class:`~apstools.devices.description_mixin.EpicsDescriptionMixin`
+     - add a record's description field to a Device, such as EpicsMotor
+   * - :class:`~apstools.devices.epics_scan_id_signal.EpicsScanIdSignal`
+     - use an EPICS PV as the source of the RunEngine's ``scan_id``
+   * - :class:`~apstools.devices.kohzu_monochromator.KohzuSeqCtl_Monochromator`
+     - synApps Kohzu double-crystal monochromator sequence control
+   * - :class:`~apstools.devices.labjack.LabJackBase`
+     - LabJack T-series data acquisition unit (DAQ)
+   * - :class:`~apstools.devices.labjack.LabJackT4`
+     - LabJack T4 DAQ
+   * - :class:`~apstools.devices.labjack.LabJackT7`
+     - LabJack T7 DAQ
+   * - :class:`~apstools.devices.labjack.LabJackT7Pro`
+     - LabJack T7 Pro DAQ
+   * - :class:`~apstools.devices.labjack.LabJackT8`
+     - LabJack T8 DAQ
+   * - :func:`~apstools.devices.dict_device_support.make_dict_device`
+     - make a recordable DictionaryDevice instance from a dictionary
+   * - :class:`~apstools.devices.measComp_usb_ctr_support.MeasCompCtr`
+     - Measurement Computing USB CTR08 high-speed counter/timer
+   * - :class:`~apstools.devices.xia_pf4.Pf4FilterBank`
+     - single module of XIA PF4 filters (4 blades)
+   * - :class:`~apstools.devices.xia_pf4.Pf4FilterCommon`
+     - XIA PF4 filters — common support
+   * - :class:`~apstools.devices.xia_pf4.Pf4FilterDual`
+     - XIA PF4 filter: two sets of 4 filters (A, B)
+   * - :class:`~apstools.devices.xia_pf4.Pf4FilterSingle`
+     - XIA PF4 filter: one set of 4 filters (A)
+   * - :class:`~apstools.devices.xia_pf4.Pf4FilterTriple`
+     - XIA PF4 filter: three sets of 4 filters (A, B, C)
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedSwaitControllerPositioner`
+     - simulated process controller as positioner with EPICS swait record
+   * - :class:`~apstools.devices.simulated_controllers.SimulatedTransformControllerPositioner`
+     - simulated process controller as positioner with EPICS transform record
+   * - :class:`~apstools.devices.srs570_preamplifier.SRS570_PreAmplifier`
+     - Stanford Research Systems 570 preamplifier from synApps
+   * - :class:`~apstools.devices.struck3820.Struck3820`
+     - Struck/SIS 3820 multi-channel scaler (as used by USAXS)
 
-
-.. issue #763
-    ~apstools.devices.flyer_motor_scaler.SignalValueStack
 
 Internal Routines
 +++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.devices.aps_machine.ApsOperatorMessagesDevice
-    ~apstools.devices.tracking_signal.TrackingSignal
-    ~apstools.devices.mixin_base.DeviceMixinBase
+   * - :class:`~apstools.devices.aps_machine.ApsOperatorMessagesDevice`
+     - general messages from the APS main control room
+   * - :class:`~apstools.devices.mixin_base.DeviceMixinBase`
+     - base class for apstools Device mixin classes
+   * - :class:`~apstools.devices.tracking_signal.TrackingSignal`
+     - non-EPICS signal for use when coordinating Device actions
 
-All Submodules
---------------
-
-.. automodule:: apstools.devices.acs_motors
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.aps_bss_user
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.aps_cycle
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.aps_data_management
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.aps_machine
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.aps_undulator
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.area_detector_factory
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.area_detector_support
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.axis_tuner
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.delay
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.description_mixin
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.dict_device_support
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.epics_scan_id_signal
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.eurotherm_2216e
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. issue #763
-    .. automodule   apstools.devices.flyer_motor_scaler
-        :members:
-        :private-members:
-        :show-inheritance:
-        :inherited-members:
-
-.. automodule:: apstools.devices.hhl_apertures
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.hhl_slits
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.kohzu_monochromator
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.labjack
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.lakeshore_controllers
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.linkam_controllers
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.measComp_tc32_support
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.measComp_usb_ctr_support
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.mixin_base
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.motor_factory
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.motor_mixins
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.positioner_soft_done
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.preamp_base
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.ptc10_controller
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.scaler_support
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.shutters
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.simulated_controllers
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.srs570_preamplifier
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.struck3820
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.synth_pseudo_voigt
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.tracking_signal
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.xia_pf4
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.devices.xia_slit
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:

--- a/docs/source/api/_filewriters.rst
+++ b/docs/source/api/_filewriters.rst
@@ -4,16 +4,25 @@
 File Writers
 ============
 
-Write data files during data acquisition.  The file writer callbacks are:
+Write data files during data acquisition.
 
-.. autosummary::
-    :nosignatures:
+For complete API details see the :doc:`Full API Reference <autoapi/apstools/index>`.
 
-   ~apstools.callbacks.callback_base.FileWriterCallbackBase
-   ~apstools.callbacks.nexus_writer.NXWriterAPS
-   ~apstools.callbacks.nexus_writer.NXWriter
-   ~apstools.callbacks.spec_file_writer.SpecWriterCallback
-   ~apstools.callbacks.spec_file_writer.SpecWriterCallback2
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
+
+   * - :class:`~apstools.callbacks.callback_base.FileWriterCallbackBase`
+     - base class for filewriter callbacks
+   * - :class:`~apstools.callbacks.nexus_writer.NXWriter`
+     - write HDF5/NeXus file using NeXus base classes
+   * - :class:`~apstools.callbacks.nexus_writer.NXWriterAPS`
+     - customize :class:`~apstools.callbacks.nexus_writer.NXWriter` with APS-specific content
+   * - :class:`~apstools.callbacks.spec_file_writer.SpecWriterCallback`
+     - (*deprecated*) write SPEC data file line-by-line
+   * - :class:`~apstools.callbacks.spec_file_writer.SpecWriterCallback2`
+     - write SPEC data file as data is collected, line-by-line
+
 
 
 Overview
@@ -32,7 +41,7 @@ Examples
 
 Write SPEC file automatically from data acquisition::
 
-    specwriter = apstools.callbacks.SpecWriterCallback()
+    specwriter = apstools.callbacks.SpecWriterCallback2()
     RE.subscribe(specwriter.receiver)
 
 Write NeXus file automatically from data acquisition::
@@ -54,12 +63,15 @@ One less import when only accessing the Databroker.
 The *only* advantage to subclassing from ``CallbackBase``
 seems to be a simpler setup call to ``RE.subscribe()``.
 
-============  ===============================
+============  ================================
 superclass    subscription code
-============  ===============================
+============  ================================
 object        ``RE.subscribe(specwriter.receiver)``
 CallbackBase  ``RE.subscribe(specwriter)``
-============  ===============================
+============  ================================
+
+``SpecWriterCallback2`` subclasses from ``object``; use
+``RE.subscribe(specwriter.receiver)`` to subscribe it.
 
 HDF5/NeXus File Writers
 ++++++++++++++++++++++++++
@@ -374,31 +386,31 @@ Examples of additional structure in NeXus file added by
     :linenos:
     :language: text
 
-.. _filewriters.SpecWriterCallback:
+.. _filewriters.SpecWriterCallback2:
 
 SPEC File Structure
 +++++++++++++++++++
 
 EXAMPLE : use as Bluesky callback::
 
-    from apstools import SpecWriterCallback
-    specwriter = SpecWriterCallback()
+    from apstools.callbacks import SpecWriterCallback2
+    specwriter = SpecWriterCallback2()
     RE.subscribe(specwriter.receiver)
 
 EXAMPLE : use as writer from Databroker::
 
-    from apstools import SpecWriterCallback
-    specwriter = SpecWriterCallback()
+    from apstools.callbacks import SpecWriterCallback2
+    specwriter = SpecWriterCallback2()
     for key, doc in db.get_documents(db["a123456"]):
         specwriter.receiver(key, doc)
-    print("Look at SPEC data file: "+specwriter.spec_filename)
+    print("Look at SPEC data file: " + specwriter.spec_filename)
 
 EXAMPLE : use as writer from Databroker with customizations::
 
-    from apstools import SpecWriterCallback
+    from apstools.callbacks import SpecWriterCallback2
 
     # write into file: /tmp/cerium.spec
-    specwriter = SpecWriterCallback(filename="/tmp/cerium.spec")
+    specwriter = SpecWriterCallback2(filename="/tmp/cerium.spec")
     for key, doc in db.get_documents(db["abcd123"]):
         specwriter.receiver(key, doc)
 
@@ -407,21 +419,11 @@ EXAMPLE : use as writer from Databroker with customizations::
     for key, doc in db.get_documents(db["b46b63d4"]):
         specwriter.receiver(key, doc)
 
-Example output from ``SpecWriterCallback()``:
+Example output from ``SpecWriterCallback2()``:
 
 .. literalinclude:: ../resources/demo_specdata.dat
     :linenos:
     :language: text
 
 
-Source Code
-++++++++++++++++
 
-.. automodule:: apstools.callbacks.callback_base
-    :members:
-
-.. automodule:: apstools.callbacks.nexus_writer
-    :members:
-
-.. automodule:: apstools.callbacks.spec_file_writer
-    :members:

--- a/docs/source/api/_plans.rst
+++ b/docs/source/api/_plans.rst
@@ -6,6 +6,8 @@ Plans
 
 Customize your measurement procedures.
 
+For complete API details see the :doc:`Full API Reference <autoapi/apstools/index>`.
+
 Plans and Support by Activity
 ------------------------------
 
@@ -14,97 +16,112 @@ Plans and Support by Activity
 Batch Scanning
 +++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.plans.command_list.execute_command_list
-   ~apstools.plans.command_list.get_command_list
-   ~apstools.plans.command_list.parse_Excel_command_file
-   ~apstools.plans.command_list.parse_text_command_file
-   ~apstools.plans.command_list.register_command_handler
-   ~apstools.plans.command_list.run_command_file
-   ~apstools.plans.command_list.summarize_command_file
+   * - :func:`~apstools.plans.command_list.execute_command_list`
+     - execute the command list as a plan
+   * - :func:`~apstools.plans.command_list.get_command_list`
+     - return command list from either text or Excel file
+   * - :func:`~apstools.plans.command_list.parse_Excel_command_file`
+     - parse an Excel spreadsheet with commands, return as command list
+   * - :func:`~apstools.plans.command_list.parse_text_command_file`
+     - parse a text file with commands, return as command list
+   * - :func:`~apstools.plans.command_list.register_command_handler`
+     - define the function called to execute the command list
+   * - :func:`~apstools.plans.command_list.run_command_file`
+     - execute a list of commands from a text or Excel file as a plan
+   * - :func:`~apstools.plans.command_list.summarize_command_file`
+     - print the command list from a text or Excel file
+
 
 .. _plans.custom:
 
 Custom Scans
 +++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.plans.alignment.edge_align
-   ~apstools.plans.alignment.lineup
-   ~apstools.plans.alignment.lineup2
-   ~apstools.plans.alignment.tune_axes
-   ~apstools.plans.alignment.TuneAxis
-   ~apstools.plans.doc_run.documentation_run
-   ~apstools.plans.labels_to_streams.label_stream_decorator
-   ~apstools.plans.nscan_support.nscan
-   ~apstools.plans.sscan_support.sscan_1D
-   ~apstools.plans.xpcs_mesh.mesh_list_grid_scan
+   * - :func:`~apstools.plans.doc_run.documentation_run`
+     - save text as a bluesky run
+   * - :func:`~apstools.plans.alignment.edge_align`
+     - align to the edge given mover and detector data, relative to absolute position
+   * - :func:`~apstools.plans.labels_to_streams.label_stream_decorator`
+     - decorator: write labeled device(s) to bluesky stream(s)
+   * - :func:`~apstools.plans.alignment.lineup`
+     - (*deprecated*) lineup and center a given axis, relative to current position
+   * - :func:`~apstools.plans.alignment.lineup2`
+     - lineup and center a given mover, relative to the current position
+   * - :func:`~apstools.plans.xpcs_mesh.mesh_list_grid_scan`
+     - scan over a multi-dimensional mesh with *n* total points per motor trajectory
+   * - :func:`~apstools.plans.nscan_support.nscan`
+     - scan over *n* variables moved together, each in equally spaced steps
+   * - :func:`~apstools.plans.sscan_support.sscan_1D`
+     - simple 1-D scan using EPICS synApps sscan record
+   * - :class:`~apstools.plans.alignment.TuneAxis`
+     - tune a single axis with a signal
+
 
 .. _plans.overall:
 
 Overall
 +++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.plans.alignment.lineup
-   ~apstools.plans.alignment.lineup2
-   ~apstools.plans.alignment.tune_axes
-   ~apstools.plans.alignment.TuneAxis
-   ~apstools.plans.command_list.command_list_as_table
-   ~apstools.plans.command_list.execute_command_list
-   ~apstools.plans.command_list.get_command_list
-   ~apstools.plans.command_list.parse_Excel_command_file
-   ~apstools.plans.command_list.parse_text_command_file
-   ~apstools.plans.command_list.register_command_handler
-   ~apstools.plans.command_list.run_command_file
-   ~apstools.plans.command_list.summarize_command_file
-   ~apstools.plans.doc_run.addDeviceDataAsStream
-   ~apstools.plans.doc_run.documentation_run
-   ~apstools.plans.doc_run.write_stream
-   ~apstools.plans.input_plan.request_input
-   ~apstools.plans.labels_to_streams.label_stream_decorator
-   ~apstools.plans.labels_to_streams.label_stream_stub
-   ~apstools.plans.labels_to_streams.label_stream_wrapper
-   ~apstools.plans.nscan_support.nscan
-   ~apstools.plans.run_blocking_function_plan.run_blocking_function
-   ~apstools.plans.sscan_support.sscan_1D
-   ~apstools.plans.stage_sigs_support.restorable_stage_sigs
-   ~apstools.plans.xpcs_mesh.mesh_list_grid_scan
+   * - :func:`~apstools.plans.doc_run.addDeviceDataAsStream`
+     - (*deprecated*) renamed to :func:`~apstools.plans.doc_run.write_stream`
+   * - :func:`~apstools.plans.command_list.command_list_as_table`
+     - format a command list as a pyRestTable table object
+   * - :func:`~apstools.plans.doc_run.documentation_run`
+     - save text as a bluesky run
+   * - :func:`~apstools.plans.command_list.execute_command_list`
+     - execute the command list as a plan
+   * - :func:`~apstools.plans.command_list.get_command_list`
+     - return command list from either text or Excel file
+   * - :func:`~apstools.plans.labels_to_streams.label_stream_decorator`
+     - decorator: write labeled device(s) to bluesky stream(s)
+   * - :func:`~apstools.plans.labels_to_streams.label_stream_stub`
+     - write ophyd-labeled objects to open bluesky run streams
+   * - :func:`~apstools.plans.labels_to_streams.label_stream_wrapper`
+     - decorator support: write labeled device(s) to stream(s)
+   * - :func:`~apstools.plans.alignment.lineup`
+     - (*deprecated*) lineup and center a given axis, relative to current position
+   * - :func:`~apstools.plans.alignment.lineup2`
+     - lineup and center a given mover, relative to the current position
+   * - :func:`~apstools.plans.xpcs_mesh.mesh_list_grid_scan`
+     - scan over a multi-dimensional mesh with *n* total points per motor trajectory
+   * - :func:`~apstools.plans.nscan_support.nscan`
+     - scan over *n* variables moved together, each in equally spaced steps
+   * - :func:`~apstools.plans.command_list.parse_Excel_command_file`
+     - parse an Excel spreadsheet with commands, return as command list
+   * - :func:`~apstools.plans.command_list.parse_text_command_file`
+     - parse a text file with commands, return as command list
+   * - :func:`~apstools.plans.command_list.register_command_handler`
+     - define the function called to execute the command list
+   * - :func:`~apstools.plans.input_plan.request_input`
+     - request input from the user during a plan
+   * - :func:`~apstools.plans.stage_sigs_support.restorable_stage_sigs`
+     - decorator: save and restore a device's stage_sigs around a plan
+   * - :func:`~apstools.plans.run_blocking_function_plan.run_blocking_function`
+     - run a blocking function as a bluesky plan in a thread
+   * - :func:`~apstools.plans.command_list.run_command_file`
+     - execute a list of commands from a text or Excel file as a plan
+   * - :func:`~apstools.plans.sscan_support.sscan_1D`
+     - simple 1-D scan using EPICS synApps sscan record
+   * - :func:`~apstools.plans.command_list.summarize_command_file`
+     - print the command list from a text or Excel file
+   * - :class:`~apstools.plans.alignment.TuneAxis`
+     - tune a single axis with a signal
+   * - :func:`~apstools.plans.doc_run.write_stream`
+     - add an ophyd Device as an additional document stream
 
 
 Also consult the :ref:`Index <genindex>` under the *Bluesky* heading
 for links to the Callbacks, Devices, Exceptions, and Plans described
 here.
-
-Submodules
----------------
-
-.. automodule:: apstools.plans.alignment
-    :members:
-
-.. automodule:: apstools.plans.command_list
-    :members:
-
-.. automodule:: apstools.plans.doc_run
-    :members:
-
-.. automodule:: apstools.plans.input_plan
-    :members:
-
-.. automodule:: apstools.plans.labels_to_streams
-    :members:
-
-.. automodule:: apstools.plans.nscan_support
-    :members:
-
-.. automodule:: apstools.plans.run_blocking_function_plan
-    :members:
-
-.. automodule:: apstools.plans.sscan_support
-    :members:
-
-.. automodule:: apstools.plans.stage_sigs_support
-    :members:

--- a/docs/source/api/_utils.rst
+++ b/docs/source/api/_utils.rst
@@ -6,9 +6,10 @@ Utilities
 
 Assists measurement, data exploration, and the user experience.
 
+For complete API details see the :doc:`Full API Reference <autoapi/apstools/index>`.
+
 Also consult the :ref:`Index <genindex>` under the *apstools* heading
-for links to the Exceptions, and Utilities described
-here.
+for links to the Exceptions, and Utilities described here.
 
 Utilities by Activity
 ----------------------
@@ -16,219 +17,259 @@ Utilities by Activity
 .. _utils.aps_dm:
 
 APS Data Management
-++++++++++++++++++++++
++++++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.aps_data_management.dm_setup
-   ~apstools.utils.aps_data_management.dm_api_cat
-   ~apstools.utils.aps_data_management.dm_api_daq
-   ~apstools.utils.aps_data_management.dm_api_dataset_cat
-   ~apstools.utils.aps_data_management.dm_api_ds
-   ~apstools.utils.aps_data_management.dm_api_file
-   ~apstools.utils.aps_data_management.dm_api_filecat
-   ~apstools.utils.aps_data_management.dm_api_proc
-   ~apstools.utils.aps_data_management.DM_WorkflowCache
+   * - :func:`~apstools.utils.aps_data_management.dm_api_cat`
+     - return the APS DM Catalog API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_daq`
+     - return the APS DM Data Acquisition API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_dataset_cat`
+     - return the APS DM Dataset Metadata Catalog API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_ds`
+     - return the APS DM Data Storage API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_file`
+     - return the APS DM File API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_filecat`
+     - return the APS DM Metadata Catalog Service API object
+   * - :func:`~apstools.utils.aps_data_management.dm_api_proc`
+     - return the APS DM Processing API object
+   * - :func:`~apstools.utils.aps_data_management.dm_setup`
+     - set up this session for APS Data Management
+   * - :class:`~apstools.utils.aps_data_management.DM_WorkflowCache`
+     - track one or more APS DM workflows for bluesky plans
+
 
 .. _utils.finding:
 
 Finding
-+++++++++++
++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.pvregistry.findbyname
-   ~apstools.utils.pvregistry.findbypv
-   ~apstools.utils.catalog.findCatalogsInNamespace
+   * - :func:`~apstools.utils.pvregistry.findbyname`
+     - find the ophyd object associated with the given ophyd name
+   * - :func:`~apstools.utils.pvregistry.findbypv`
+     - find all ophyd objects associated with the given EPICS PV
+   * - :func:`~apstools.utils.catalog.findCatalogsInNamespace`
+     - return a dictionary of databroker catalogs in the default namespace
+
 
 .. _utils.listing:
 
 Listing
-+++++++++++
++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.device_info.listdevice
-   ~apstools.utils.misc.listobjects
-   ~apstools.utils.list_plans.listplans
-   ~apstools.utils.list_runs.listRunKeys
-   ~apstools.utils.list_runs.ListRuns
-   ~apstools.utils.list_runs.listruns
+   * - :func:`~apstools.utils.device_info.listdevice`
+     - describe signal information from a device in a pandas DataFrame
+   * - :func:`~apstools.utils.misc.listobjects`
+     - show all ophyd Signal and Device objects defined as globals
+   * - :func:`~apstools.utils.list_plans.listplans`
+     - list all plans
+   * - :func:`~apstools.utils.list_runs.listRunKeys`
+     - list all keys (column names) in a scan's stream
+   * - :class:`~apstools.utils.list_runs.ListRuns`
+     - list runs from a catalog according to some options
+   * - :func:`~apstools.utils.list_runs.listruns`
+     - list runs from catalog
+
 
 .. _utils.reporting:
 
 Reporting
-+++++++++++
++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.misc.print_RE_md
-   ~apstools.utils.log_utils.file_log_handler
-   ~apstools.utils.log_utils.get_log_path
-   ~apstools.utils.log_utils.setup_IPython_console_logging
-   ~apstools.utils.slit_core.SlitGeometry
-   ~apstools.utils.log_utils.stream_log_handler
+   * - :func:`~apstools.utils.log_utils.file_log_handler`
+     - record logging output to a file
+   * - :func:`~apstools.utils.log_utils.get_log_path`
+     - return a path to ``./.logs``
+   * - :func:`~apstools.utils.misc.print_RE_md`
+     - print the RunEngine metadata in a table
+   * - :func:`~apstools.utils.log_utils.setup_IPython_console_logging`
+     - record all input and output from the IPython console
+   * - :class:`~apstools.utils.slit_core.SlitGeometry`
+     - slit size and center as a named tuple
+   * - :func:`~apstools.utils.log_utils.stream_log_handler`
+     - record logging output to a stream such as the console
+
 
 .. _utils.other:
 
 Other Utilities
-++++++++++++++++
++++++++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.statistics.array_index
-   ~apstools.utils.misc.cleanupText
-   ~apstools.utils.misc.connect_pvlist
-   ~apstools.utils.aps_data_management.dm_setup
-   ~apstools.utils.misc.dynamic_import
-   ~apstools.utils.email.EmailNotifications
-   ~apstools.utils.statistics.factor_fwhm
-   ~apstools.utils.statistics.peak_full_width
-   ~apstools.utils.plot.select_live_plot
-   ~apstools.utils.plot.select_mpl_figure
-   ~apstools.utils.plot.trim_plot_by_name
-   ~apstools.utils.plot.trim_plot_lines
-   ~apstools.utils.misc.trim_string_for_EPICS
-   ~apstools.utils.time_constants.ts2iso
-   ~apstools.utils.misc.unix
-   ~apstools.utils.apsu_controls_subnet.warn_if_not_aps_controls_subnet
-   ~apstools.utils.statistics.xy_statistics
+   * - :func:`~apstools.utils.statistics.array_index`
+     - return the index of the first occurrence of value in an array
+   * - :func:`~apstools.utils.misc.cleanupText`
+     - convert text so it can be used as a dictionary key
+   * - :func:`~apstools.utils.misc.connect_pvlist`
+     - given a list of EPICS PV names, return a dict of EpicsSignal objects
+   * - :func:`~apstools.utils.misc.dynamic_import`
+     - import the object given its import path as text
+   * - :class:`~apstools.utils.email.EmailNotifications`
+     - send email notifications when requested
+   * - :data:`~apstools.utils.statistics.factor_fwhm`
+     - conversion factor between FWHM and standard deviation
+   * - :func:`~apstools.utils.statistics.peak_full_width`
+     - assess apparent FWHM by inspecting the data
+   * - :func:`~apstools.utils.plot.plotxy`
+     - plot y vs x from a bluesky run
+   * - :func:`~apstools.utils.plot.select_live_plot`
+     - get the first live plot matching a signal
+   * - :func:`~apstools.utils.plot.select_mpl_figure`
+     - get the matplotlib Figure window for y vs x
+   * - :func:`~apstools.utils.plot.trim_plot_by_name`
+     - replot with at most the last *n* lines, by figure name
+   * - :func:`~apstools.utils.plot.trim_plot_lines`
+     - replot with at most the last *n* lines for given x and y axes
+   * - :func:`~apstools.utils.misc.trim_string_for_EPICS`
+     - ensure a string does not exceed EPICS PV length
+   * - :func:`~apstools.utils.time_constants.ts2iso`
+     - convert Python timestamp (float) to ISO 8601 time in current time zone
+   * - :func:`~apstools.utils.misc.unix`
+     - run a UNIX command, return (stdout, stderr)
+   * - :func:`~apstools.utils.apsu_controls_subnet.warn_if_not_aps_controls_subnet`
+     - warn if not on APS-U controls subnet
+   * - :func:`~apstools.utils.statistics.xy_statistics`
+     - compute statistical measures of a 1-D array using numpy
+
 
 .. _utils.general:
 
 General
-+++++++++++
++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.utils.misc.call_signature_decorator
-   ~apstools.utils.misc.cleanupText
-   ~apstools.plans.command_list.command_list_as_table
-   ~apstools.utils.misc.connect_pvlist
-   ~apstools.utils.catalog.copy_filtered_catalog
-   ~apstools.utils.query.db_query
-   ~apstools.utils.misc.dictionary_table
-   ~apstools.utils.misc.dynamic_import
-   ~apstools.utils.email.EmailNotifications
-   ~apstools.utils.spreadsheet.ExcelDatabaseFileBase
-   ~apstools.utils.spreadsheet.ExcelDatabaseFileGeneric
-   ~apstools.utils.spreadsheet.ExcelReadError
-   ~apstools.utils.pvregistry.findbyname
-   ~apstools.utils.pvregistry.findbypv
-   ~apstools.utils.catalog.findCatalogsInNamespace
-   ~apstools.utils.misc.full_dotted_name
-   ~apstools.utils.catalog.getCatalog
-   ~apstools.utils.catalog.getDatabase
-   ~apstools.utils.catalog.getDefaultCatalog
-   ~apstools.utils.catalog.getDefaultDatabase
-   ~apstools.utils.profile_support.getDefaultNamespace
-   ~apstools.utils.descriptor_support.get_stream_data_map
-   ~apstools.utils.list_runs.getRunData
-   ~apstools.utils.list_runs.getRunDataValue
-   ~apstools.utils.catalog.getStreamValues
-   ~apstools.utils.profile_support.ipython_profile_name
-   ~apstools.utils.misc.itemizer
-   ~apstools.utils.device_info.listdevice
-   ~apstools.utils.misc.listobjects
-   ~apstools.utils.list_plans.listplans
-   ~apstools.utils.list_runs.listRunKeys
-   ~apstools.utils.list_runs.ListRuns
-   ~apstools.utils.list_runs.listruns
-   ~apstools.utils.mmap_dict.MMap
-   ~apstools.utils.override_parameters.OverrideParameters
-   ~apstools.utils.misc.pairwise
-   ~apstools.utils.plot.plotxy
-   ~apstools.utils.misc.print_RE_md
-   ~apstools.utils.catalog.quantify_md_key_use
-   ~apstools.utils.misc.redefine_motor_position
-   ~apstools.utils.misc.render
-   ~apstools.utils.misc.replay
-   ~apstools.utils.memory.rss_mem
-   ~apstools.utils.misc.run_in_thread
-   ~apstools.utils.misc.safe_ophyd_name
-   ~apstools.utils.plot.select_live_plot
-   ~apstools.utils.plot.select_mpl_figure
-   ~apstools.utils.misc.split_quoted_line
-   ~apstools.utils.stored_dict.StoredDict
-   ~apstools.utils.list_runs.summarize_runs
-   ~apstools.utils.misc.text_encode
-   ~apstools.utils.misc.to_unicode_or_bust
-   ~apstools.utils.plot.trim_plot_by_name
-   ~apstools.utils.plot.trim_plot_lines
-   ~apstools.utils.misc.trim_string_for_EPICS
-   ~apstools.utils.misc.unix
+   * - :func:`~apstools.utils.misc.call_signature_decorator`
+     - get the names of all function parameters supplied by the caller
+   * - :func:`~apstools.utils.misc.cleanupText`
+     - convert text so it can be used as a dictionary key
+   * - :func:`~apstools.plans.command_list.command_list_as_table`
+     - format a command list as a pyRestTable table object
+   * - :func:`~apstools.utils.misc.connect_pvlist`
+     - given a list of EPICS PV names, return a dict of EpicsSignal objects
+   * - :func:`~apstools.utils.catalog.copy_filtered_catalog`
+     - copy filtered runs from source catalog to target catalog
+   * - :func:`~apstools.utils.query.db_query`
+     - search the databroker v2 database
+   * - :func:`~apstools.utils.misc.dictionary_table`
+     - return a text table from a dictionary
+   * - :func:`~apstools.utils.misc.dynamic_import`
+     - import the object given its import path as text
+   * - :class:`~apstools.utils.email.EmailNotifications`
+     - send email notifications when requested
+   * - :class:`~apstools.utils.spreadsheet.ExcelDatabaseFileBase`
+     - base class: read-only support for Excel files as databases
+   * - :class:`~apstools.utils.spreadsheet.ExcelDatabaseFileGeneric`
+     - generic read-only handling of Excel spreadsheet-as-database
+   * - :class:`~apstools.utils.spreadsheet.ExcelReadError`
+     - exception when reading Excel spreadsheet
+   * - :func:`~apstools.utils.pvregistry.findbyname`
+     - find the ophyd object associated with the given ophyd name
+   * - :func:`~apstools.utils.pvregistry.findbypv`
+     - find all ophyd objects associated with the given EPICS PV
+   * - :func:`~apstools.utils.catalog.findCatalogsInNamespace`
+     - return a dictionary of databroker catalogs in the default namespace
+   * - :func:`~apstools.utils.misc.full_dotted_name`
+     - return the full dotted name of an ophyd object
+   * - :func:`~apstools.utils.descriptor_support.get_stream_data_map`
+     - return the names of run's detector and motor signals
+   * - :func:`~apstools.utils.catalog.getCatalog`
+     - return a catalog object
+   * - :func:`~apstools.utils.catalog.getDatabase`
+     - return a bluesky database using keyword guides or default choice
+   * - :func:`~apstools.utils.catalog.getDefaultCatalog`
+     - return the default databroker catalog
+   * - :func:`~apstools.utils.catalog.getDefaultDatabase`
+     - find the default database (has the most recent run)
+   * - :func:`~apstools.utils.profile_support.getDefaultNamespace`
+     - get the IPython shell's namespace dictionary
+   * - :func:`~apstools.utils.list_runs.getRunData`
+     - get the run's data
+   * - :func:`~apstools.utils.list_runs.getRunDataValue`
+     - get value of key in run stream
+   * - :func:`~apstools.utils.catalog.getStreamValues`
+     - get values from a previous scan stream in a databroker catalog
+   * - :func:`~apstools.utils.profile_support.ipython_profile_name`
+     - return the name of the current IPython profile
+   * - :func:`~apstools.utils.misc.itemizer`
+     - format a list of items
+   * - :func:`~apstools.utils.device_info.listdevice`
+     - describe signal information from a device in a pandas DataFrame
+   * - :func:`~apstools.utils.misc.listobjects`
+     - show all ophyd Signal and Device objects defined as globals
+   * - :func:`~apstools.utils.list_plans.listplans`
+     - list all plans
+   * - :func:`~apstools.utils.list_runs.listRunKeys`
+     - list all keys (column names) in a scan's stream
+   * - :class:`~apstools.utils.list_runs.ListRuns`
+     - list runs from a catalog according to some options
+   * - :func:`~apstools.utils.list_runs.listruns`
+     - list runs from catalog
+   * - :class:`~apstools.utils.mmap_dict.MMap`
+     - dictionary with keys accessible as attributes (read-only)
+   * - :class:`~apstools.utils.override_parameters.OverrideParameters`
+     - define parameters that can be overridden from a user configuration file
+   * - :func:`~apstools.utils.misc.pairwise`
+     - break a list into pairs
+   * - :func:`~apstools.utils.plot.plotxy`
+     - plot y vs x from a bluesky run
+   * - :func:`~apstools.utils.misc.print_RE_md`
+     - print the RunEngine metadata in a table
+   * - :func:`~apstools.utils.catalog.quantify_md_key_use`
+     - print table of different key values and how many times each appears
+   * - :func:`~apstools.utils.misc.redefine_motor_position`
+     - set EPICS motor record's user coordinate to a new position
+   * - :func:`~apstools.utils.misc.render`
+     - round floating-point numbers to significant figures
+   * - :func:`~apstools.utils.misc.replay`
+     - replay the document stream from one or more scans
+   * - :func:`~apstools.utils.memory.rss_mem`
+     - return memory used by this process
+   * - :func:`~apstools.utils.misc.run_in_thread`
+     - decorator: run a function in a thread
+   * - :func:`~apstools.utils.misc.safe_ophyd_name`
+     - make text safe to be used as an ophyd object name
+   * - :func:`~apstools.utils.plot.select_live_plot`
+     - get the first live plot matching a signal
+   * - :func:`~apstools.utils.plot.select_mpl_figure`
+     - get the matplotlib Figure window for y vs x
+   * - :func:`~apstools.utils.misc.split_quoted_line`
+     - split a line into words, some of which may be quoted
+   * - :class:`~apstools.utils.stored_dict.StoredDict`
+     - a MutableMapping which syncs its contents to storage
+   * - :func:`~apstools.utils.list_runs.summarize_runs`
+     - report bluesky run metrics from the databroker
+   * - :func:`~apstools.utils.misc.text_encode`
+     - encode source using the default codepoint
+   * - :func:`~apstools.utils.misc.to_unicode_or_bust`
+     - convert bytes to unicode
+   * - :func:`~apstools.utils.plot.trim_plot_by_name`
+     - replot with at most the last *n* lines, by figure name
+   * - :func:`~apstools.utils.plot.trim_plot_lines`
+     - replot with at most the last *n* lines for given x and y axes
+   * - :func:`~apstools.utils.misc.trim_string_for_EPICS`
+     - ensure a string does not exceed EPICS PV length
+   * - :func:`~apstools.utils.misc.unix`
+     - run a UNIX command, return (stdout, stderr)
 
-Submodules
----------------
-
-.. automodule:: apstools.utils.aps_data_management
-    :members:
-    :private-members:
-    :show-inheritance:
-    :inherited-members:
-
-.. automodule:: apstools.utils.apsu_controls_subnet
-    :members:
-
-.. automodule:: apstools.utils.catalog
-    :members:
-
-.. automodule:: apstools.utils.descriptor_support
-    :members:
-
-.. automodule:: apstools.utils.device_info
-    :members:
-
-.. automodule:: apstools.utils.email
-    :members:
-
-.. automodule:: apstools.utils.image_analysis
-    :members:
-
-.. automodule:: apstools.utils.list_plans
-    :members:
-
-.. automodule:: apstools.utils.list_runs
-    :members:
-
-.. automodule:: apstools.utils.log_utils
-    :members:
-
-.. automodule:: apstools.utils.memory
-    :members:
-
-.. automodule:: apstools.utils.misc
-    :members:
-
-.. automodule:: apstools.utils.mmap_dict
-    :members:
-
-.. automodule:: apstools.utils.override_parameters
-    :members:
-
-.. automodule:: apstools.utils.plot
-    :members:
-
-.. automodule:: apstools.utils.profile_support
-    :members:
-
-.. automodule:: apstools.utils.pvregistry
-    :members:
-
-.. automodule:: apstools.utils.query
-    :members:
-
-.. automodule:: apstools.utils.slit_core
-    :members:
-
-.. automodule:: apstools.utils.spreadsheet
-    :members:
-
-.. automodule:: apstools.utils.statistics
-    :members:
-
-.. automodule:: apstools.utils.stored_dict
-    :members:
-
-.. automodule:: apstools.utils.time_constants
-    :members:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,7 +1,7 @@
 .. _api_documentation:
 
-API Documentation
-=================
+API
+===
 
 Ophyd-style support for EPICS & synApps structures (records and databases).
 
@@ -12,6 +12,7 @@ Ophyd-style support for EPICS & synApps structures (records and databases).
 
    _*
    synApps/index
+   autoapi/apstools/index
 
 .. icons: https://fonts.google.com/icons
 .. grid:: 2
@@ -39,3 +40,8 @@ Ophyd-style support for EPICS & synApps structures (records and databases).
     .. grid-item-card:: :material-regular:`plumbing;3em` :ref:`utilities`
 
       Assists measurement, data exploration, and the user experience.
+
+    .. grid-item-card:: :material-regular:`menu_book;3em` `Full API Reference <autoapi/apstools/index.html>`_
+
+      Complete, auto-generated reference for every public module, class,
+      function, and constant in *apstools*.

--- a/docs/source/api/synApps/__common.rst
+++ b/docs/source/api/synApps/__common.rst
@@ -7,7 +7,3 @@ mixin classes for the various ophyd-style devices.
 
 ..  [#] https://docs.epics-controls.org/en/latest/guides/EPICS_Intro.html#ioc-database,
 ..  [#] https://epics.anl.gov/base/R7-0/6-docs/RecordReference.html
-
-.. automodule:: apstools.synApps._common
-    :members:
-

--- a/docs/source/api/synApps/_acalcout.rst
+++ b/docs/source/api/synApps/_acalcout.rst
@@ -4,6 +4,3 @@ EPICS base aCalcout record
 
 The ``aCalcout`` record is part of EPICS base:
 https://epics-modules.github.io/calc/aCalcoutRecord.html
-
-.. automodule:: apstools.synApps.acalcout
-    :members:

--- a/docs/source/api/synApps/_asyn.rst
+++ b/docs/source/api/synApps/_asyn.rst
@@ -4,7 +4,3 @@ synApps asyn record
 
 see the synApps ``asyn`` module suppport:
 https://github.com/epics-modules/asyn
-
-.. automodule:: apstools.synApps.asyn
-    :members:
-

--- a/docs/source/api/synApps/_busy.rst
+++ b/docs/source/api/synApps/_busy.rst
@@ -4,6 +4,3 @@ synApps busy record
 
 see the synApps ``busy`` module suppport:
 https://github.com/epics-modules/busy
-
-.. automodule:: apstools.synApps.busy
-    :members:

--- a/docs/source/api/synApps/_calcout.rst
+++ b/docs/source/api/synApps/_calcout.rst
@@ -4,6 +4,3 @@ EPICS base calcout record
 
 The ``calcout`` record is part of EPICS base:
 https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14_Calcout
-
-.. automodule:: apstools.synApps.calcout
-    :members:

--- a/docs/source/api/synApps/_db_2slit.rst
+++ b/docs/source/api/synApps/_db_2slit.rst
@@ -1,7 +1,3 @@
 
 EPICS synApps optics 2slit.db
 -----------------------------
-
-
-.. automodule:: apstools.synApps.db_2slit
-    :members:

--- a/docs/source/api/synApps/_epid.rst
+++ b/docs/source/api/synApps/_epid.rst
@@ -7,6 +7,3 @@ https://epics.anl.gov/bcda/synApps/std/epidRecord.html
 
 The ``fb_epid`` database is part of the ``optics`` module:
 https://github.com/epics-modules/optics/blob/master/opticsApp/Db/fb_epid.db
-
-.. automodule:: apstools.synApps.epid
-    :members:

--- a/docs/source/api/synApps/_iocstats.rst
+++ b/docs/source/api/synApps/_iocstats.rst
@@ -4,6 +4,3 @@ synApps IOC statistics
 
 The synApps iocStats support is in the synApps ``iocStats`` module:
 https://github.com/epics-modules/iocStats
-
-.. automodule:: apstools.synApps.iocstats
-    :members:

--- a/docs/source/api/synApps/_luascript.rst
+++ b/docs/source/api/synApps/_luascript.rst
@@ -4,6 +4,3 @@ synApps luascript record
 
 see the synApps ``luascript`` module suppport:
 https://epics-lua.readthedocs.io/en/latest/luascriptRecord.html
-
-.. automodule:: apstools.synApps.luascript
-    :members:

--- a/docs/source/api/synApps/_save_data.rst
+++ b/docs/source/api/synApps/_save_data.rst
@@ -4,6 +4,3 @@ synApps save data
 
 The synApps SaveData support is in the synApps ``sscan`` module:
 https://github.com/epics-modules/sscan
-
-.. automodule:: apstools.synApps.save_data
-    :members:

--- a/docs/source/api/synApps/_scalcout.rst
+++ b/docs/source/api/synApps/_scalcout.rst
@@ -4,6 +4,3 @@ EPICS synApps calc scalcout record
 
 The ``scalcout`` record is part of EPICS synApps ``calc``:
 http://htmlpreview.github.io/?https://github.com/epics-modules/calc/blob/R3-6-1/documentation/calcDocs.html
-
-.. automodule:: apstools.synApps.scalcout
-    :members:

--- a/docs/source/api/synApps/_sscan.rst
+++ b/docs/source/api/synApps/_sscan.rst
@@ -4,6 +4,3 @@ synApps sscan record
 
 see the synApps ``sscan`` module suppport:
 https://github.com/epics-modules/sscan
-
-.. automodule:: apstools.synApps.sscan
-    :members:

--- a/docs/source/api/synApps/_sseq.rst
+++ b/docs/source/api/synApps/_sseq.rst
@@ -4,6 +4,3 @@ synApps sseq record
 
 The ``sseq`` (String Sequence) record is part of the ``calc`` module:
     :see: https://htmlpreview.github.io/?https://raw.githubusercontent.com/epics-modules/calc/R3-6-1/documentation/sseqRecord.html
-
-.. automodule:: apstools.synApps.sseq
-    :members:

--- a/docs/source/api/synApps/_sub.rst
+++ b/docs/source/api/synApps/_sub.rst
@@ -6,6 +6,3 @@ The ``sub`` record is part of EPICS base:
 https://epics.anl.gov/base/R7-0/6-docs/subRecord.html
 
 The user average databases (``$(P)userAve$(N)``) are from synApps.
-
-.. automodule:: apstools.synApps.sub
-    :members:

--- a/docs/source/api/synApps/_swait.rst
+++ b/docs/source/api/synApps/_swait.rst
@@ -7,6 +7,3 @@ https://htmlpreview.github.io/?https://raw.githubusercontent.com/epics-modules/c
 
 see the synApps ``calc`` module suppport:
 https://github.com/epics-modules/calc
-
-.. automodule:: apstools.synApps.swait
-    :members:

--- a/docs/source/api/synApps/_transform.rst
+++ b/docs/source/api/synApps/_transform.rst
@@ -4,6 +4,3 @@ synApps transform record
 
 The ``transform`` record is part of the ``calc`` module:
     :see: https://htmlpreview.github.io/?https://raw.githubusercontent.com/epics-modules/calc/R3-6-1/documentation/TransformRecord.html#Fields
-
-.. automodule:: apstools.synApps.transform
-    :members:

--- a/docs/source/api/synApps/index.rst
+++ b/docs/source/api/synApps/index.rst
@@ -6,6 +6,8 @@ synApps
 
 Ophyd-style support for EPICS synApps structures (records and databases).
 
+For complete API details see the :doc:`Full API Reference <../autoapi/apstools/index>`.
+
 EXAMPLES::
 
     import apstools.synApps
@@ -33,83 +35,148 @@ Support the default structures as provided by the synApps template XXX [#]_ IOC.
 Also support, as needed, for structures from EPICS base.
 
 Records
-+++++++++++++++++++
++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-    ~apstools.synApps.asyn.AsynRecord
-    ~apstools.synApps.busy.BusyRecord
-    ~apstools.synApps.calcout.CalcoutRecord
-    ~apstools.synApps.epid.EpidRecord
-    ~apstools.synApps.luascript.LuascriptRecord
-    ~apstools.synApps.scalcout.ScalcoutRecord
-    ~apstools.synApps.sscan.SscanRecord
-    ~apstools.synApps.sseq.SseqRecord
-    ~apstools.synApps.sub.SubRecord
-    ~apstools.synApps.swait.SwaitRecord
-    ~apstools.synApps.transform.TransformRecord
+   * - :class:`~apstools.synApps.asyn.AsynRecord`
+     - EPICS asyn record support
+   * - :class:`~apstools.synApps.busy.BusyRecord`
+     - EPICS synApps busy record
+   * - :class:`~apstools.synApps.calcout.CalcoutRecord`
+     - EPICS base calcout record support
+   * - :class:`~apstools.synApps.epid.EpidRecord`
+     - EPICS synApps epid record support
+   * - :class:`~apstools.synApps.luascript.LuascriptRecord`
+     - EPICS synApps luascript record
+   * - :class:`~apstools.synApps.scalcout.ScalcoutRecord`
+     - EPICS synApps scalcout record support
+   * - :class:`~apstools.synApps.sscan.SscanRecord`
+     - EPICS synApps sscan record
+   * - :class:`~apstools.synApps.sseq.SseqRecord`
+     - EPICS synApps sseq record support
+   * - :class:`~apstools.synApps.sub.SubRecord`
+     - EPICS base sub record support
+   * - :class:`~apstools.synApps.swait.SwaitRecord`
+     - EPICS synApps swait record
+   * - :class:`~apstools.synApps.transform.TransformRecord`
+     - EPICS transform record support
+
 
 The ophyd-style Devices for these records rely on common structures:
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.synApps._common.EpicsRecordDeviceCommonAll
-   ~apstools.synApps._common.EpicsRecordInputFields
-   ~apstools.synApps._common.EpicsRecordOutputFields
-   ~apstools.synApps._common.EpicsRecordFloatFields
+   * - :class:`~apstools.synApps._common.EpicsRecordDeviceCommonAll`
+     - fields common to all EPICS records
+   * - :class:`~apstools.synApps._common.EpicsRecordFloatFields`
+     - fields common to EPICS records supporting floating point values
+   * - :class:`~apstools.synApps._common.EpicsRecordInputFields`
+     - fields common to EPICS input records
+   * - :class:`~apstools.synApps._common.EpicsRecordOutputFields`
+     - fields common to EPICS output records
+
 
 Databases
-+++++++++++++++++++
++++++++++
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.synApps.sseq.EditStringSequence
-   ~apstools.synApps.db_2slit.Optics2Slit1D
-   ~apstools.synApps.db_2slit.Optics2Slit2D_HV
-   ~apstools.synApps.db_2slit.Optics2Slit2D_InbOutBotTop
-   ~apstools.synApps.save_data.SaveData
-   ~apstools.synApps.sscan.SscanDevice
-   ~apstools.synApps.swait.UserCalcN
-   ~apstools.synApps.swait.UserCalcsDevice
-   ~apstools.synApps.calcout.UserCalcoutDevice
-   ~apstools.synApps.calcout.UserCalcoutN
-   ~apstools.synApps.scalcout.UserScalcoutDevice
-   ~apstools.synApps.scalcout.UserScalcoutN
-   ~apstools.synApps.luascript.UserScriptsDevice
-   ~apstools.synApps.sseq.UserStringSequenceDevice
-   ~apstools.synApps.sseq.UserStringSequenceN
-   ~apstools.synApps.sub.UserAverageN
-   ~apstools.synApps.sub.UserAverageDevice
-   ~apstools.synApps.transform.UserTransformN
-   ~apstools.synApps.transform.UserTransformsDevice
+   * - :class:`~apstools.synApps.sseq.EditStringSequence`
+     - quickly re-arrange steps in an sseq record
+   * - :class:`~apstools.synApps.iocstats.IocStatsDevice`
+     - synApps IOC stats
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit1D`
+     - synApps optics 2slit.db 1D support: xn, xp, size, center, sync
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit2D_HV`
+     - synApps optics 2slit.db 2D support: h.xn, h.xp, v.xn, v.xp
+   * - :class:`~apstools.synApps.db_2slit.Optics2Slit2D_InbOutBotTop`
+     - synApps optics 2slit.db 2D support: inb, out, bot, top
+   * - :class:`~apstools.synApps.save_data.SaveData`
+     - synApps saveData support
+   * - :class:`~apstools.synApps.sscan.SscanDevice`
+     - synApps XXX IOC setup of sscan records
+   * - :class:`~apstools.synApps.sub.UserAverageDevice`
+     - synApps XXX IOC setup of user averaging sub records
+   * - :class:`~apstools.synApps.sub.UserAverageN`
+     - single instance of the user average sub record
+   * - :class:`~apstools.synApps.swait.UserCalcN`
+     - single instance of the userCalcN database
+   * - :class:`~apstools.synApps.calcout.UserCalcoutDevice`
+     - synApps XXX IOC setup of user calcouts
+   * - :class:`~apstools.synApps.calcout.UserCalcoutN`
+     - single instance of the userCalcoutN database
+   * - :class:`~apstools.synApps.swait.UserCalcsDevice`
+     - synApps XXX IOC setup of userCalcs
+   * - :class:`~apstools.synApps.scalcout.UserScalcoutDevice`
+     - synApps XXX IOC setup of user scalcouts
+   * - :class:`~apstools.synApps.scalcout.UserScalcoutN`
+     - single instance of the userStringCalcN database
+   * - :class:`~apstools.synApps.luascript.UserScriptsDevice`
+     - synApps XXX IOC setup of user lua scripts
+   * - :class:`~apstools.synApps.sseq.UserStringSequenceDevice`
+     - synApps XXX IOC setup of userStringSeqs
+   * - :class:`~apstools.synApps.sseq.UserStringSequenceN`
+     - single instance of the userStringSeqN database
+   * - :class:`~apstools.synApps.transform.UserTransformN`
+     - single instance of the userTranN database
+   * - :class:`~apstools.synApps.transform.UserTransformsDevice`
+     - synApps XXX IOC setup of userTransforms
 
-.. autosummary::
 
-   ~apstools.synApps._common.EpicsSynAppsRecordEnableMixin
-   ~apstools.synApps.calcout.CalcoutRecordChannel
-   ~apstools.synApps.iocstats.IocStatsDevice
-   ~apstools.synApps.luascript.LuascriptRecordNumberInput
-   ~apstools.synApps.luascript.LuascriptRecordStringInput
-   ~apstools.synApps.scalcout.ScalcoutRecordNumberChannel
-   ~apstools.synApps.scalcout.ScalcoutRecordStringChannel
-   ~apstools.synApps.sub.SubRecordChannel
-   ~apstools.synApps.swait.SwaitRecordChannel
+Common support structures:
+
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
+
+   * - :class:`~apstools.synApps.calcout.CalcoutRecordChannel`
+     - channel of a calcout record: A–L
+   * - :class:`~apstools.synApps._common.EpicsSynAppsRecordEnableMixin`
+     - supports ``{PV}Enable`` feature from user databases
+   * - :class:`~apstools.synApps.luascript.LuascriptRecordNumberInput`
+     - number input of a luascript record: A–J
+   * - :class:`~apstools.synApps.luascript.LuascriptRecordStringInput`
+     - string input of a luascript record: AA–JJ
+   * - :class:`~apstools.synApps.scalcout.ScalcoutRecordNumberChannel`
+     - number channel of a scalcout record: A–L
+   * - :class:`~apstools.synApps.scalcout.ScalcoutRecordStringChannel`
+     - string channel of a scalcout record: AA–LL
+   * - :class:`~apstools.synApps.sub.SubRecordChannel`
+     - number channel of a sub record: A–L
+   * - :class:`~apstools.synApps.swait.SwaitRecordChannel`
+     - single channel of a swait record: A–L
+
 
 Other Support
 +++++++++++++
 
-These functions configure calcout or swait records
-for certain algorithms.
+These functions configure calcout or swait records for certain algorithms.
 
-.. autosummary::
+.. list-table::
+   :header-rows: 0
+   :widths: 40 60
 
-   ~apstools.synApps.calcout.setup_gaussian_calcout
-   ~apstools.synApps.calcout.setup_incrementer_calcout
-   ~apstools.synApps.calcout.setup_lorentzian_calcout
-   ~apstools.synApps.swait.setup_gaussian_swait
-   ~apstools.synApps.swait.setup_incrementer_swait
-   ~apstools.synApps.swait.setup_lorentzian_swait
-   ~apstools.synApps.swait.setup_random_number_swait
+   * - :func:`~apstools.synApps.calcout.setup_gaussian_calcout`
+     - set up calcout record for a noisy Gaussian
+   * - :func:`~apstools.synApps.swait.setup_gaussian_swait`
+     - set up swait record for a noisy Gaussian
+   * - :func:`~apstools.synApps.calcout.setup_incrementer_calcout`
+     - set up calcout record as an incrementer
+   * - :func:`~apstools.synApps.swait.setup_incrementer_swait`
+     - set up swait record as an incrementer
+   * - :func:`~apstools.synApps.calcout.setup_lorentzian_calcout`
+     - set up calcout record for a noisy Lorentzian
+   * - :func:`~apstools.synApps.swait.setup_lorentzian_swait`
+     - set up swait record for a noisy Lorentzian
+   * - :func:`~apstools.synApps.swait.setup_random_number_swait`
+     - set up swait record to generate random numbers
 
 
 All Submodules

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,8 +59,8 @@ with open(switcher_file) as fp:
 extensions = """
     IPython.sphinxext.ipython_console_highlighting
     IPython.sphinxext.ipython_directive
+    autoapi.extension
     sphinx.ext.autodoc
-    sphinx.ext.autosummary
     sphinx.ext.coverage
     sphinx.ext.githubpages
     sphinx.ext.inheritance_diagram
@@ -83,6 +83,38 @@ nb_execution_mode = "off"
 
 today_fmt = "%Y-%m-%d %H:%M"
 
+# -- autoapi configuration ---------------------------------------------------
+# https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
+
+autoapi_dirs = ["../../apstools"]
+autoapi_root = "api/autoapi"  # nested inside the existing api/ section
+autoapi_add_toctree_entry = False  # added manually to api/index.rst
+autoapi_ignore = [
+    "**/tests/**",
+    "**/test_*.py",
+    "**/conftest.py",
+    "**/_version.py",
+]
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+]
+autoapi_member_order = "alphabetical"
+autoapi_template_dir = "_templates/autoapi"
+
+
+def autoapi_skip_member(app, what, name, obj, skip, options):
+    """Skip logger instances from the autoapi output."""
+    if what == "data" and name.endswith(".logger"):
+        return True
+    return skip
+
+
+def setup(app):
+    app.connect("autoapi-skip-member", autoapi_skip_member)
+
+
 html_css_files = [
     "css/custom.css",
 ]
@@ -102,32 +134,10 @@ html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
         "json_url": switcher_json_url,
-        "version_match": 
-            release 
-            if release in switcher_version_list 
+        "version_match":
+            release
+            if release in switcher_version_list
             else "dev",
     }
 }
 # fmt: on
-
-autodoc_mock_imports = """
-    bluesky
-    dask
-    databroker
-    databroker_pack
-    epics
-    h5py
-    intake
-    numpy
-    openpyxl
-    ophyd
-    pandas
-    pint
-    psutil
-    pyRestTable
-    pysumreg
-    scipy
-    spec2nexus
-    toolz
-    xarray
-""".split()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ doc = [
   "pygments-ipython-console",
   "setuptools-scm",
   "sphinx",
+  "sphinx-autoapi",
   "sphinx-design",
 ]
 all = ["apstools[dev,doc]"]


### PR DESCRIPTION
- Closes #1081

## Summary

- Replace `sphinx.ext.autosummary` and `.. automodule::` directives with `sphinx-autoapi` for auto-generated, always-current API reference.
- Curated topic pages (Callbacks, Devices, File Writers, Plans, Utilities, synApps) retained as hand-maintained list-table indexes with one-liner descriptions that cross-reference into auto-generated pages.
- Custom autoapi templates provide concise page titles (short name as heading, full import path in monospace `Import:` line), matching the style of `Bases:` lines.
- New "Full API Reference" card in the API index links to the complete auto-generated module tree.
- Logger instances and conftest files excluded from autoapi output.
- `_filewriters.rst` examples updated from deprecated `SpecWriterCallback` to `SpecWriterCallback2`.
- AGENTS.md updated with bullet list maintenance rules and alphabetical sort requirement.
- CHANGES.rst entries sorted alphabetically within each subsection.